### PR TITLE
Docs: establish restart workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent Guide
+
+This repo uses GitHub Issues as the work tracker. Do not implement work that is not represented by an issue unless the user explicitly asks for a small direct fix.
+
+## Working Rules
+
+- Start from the relevant issue.
+- Use an issue-numbered branch: `issue-<number>-short-slug`.
+- Open a draft PR early for each issue branch.
+- Keep PRs scoped to one issue unless the user explicitly approves combining work.
+- Link the issue in the PR body.
+- Use `Closes #<number>` only when the PR is ready to merge.
+
+## Product Rules
+
+- Facets v1 is canvas-first.
+- React Flow is the rendering surface, not the domain model.
+- Store Brief, Direction, Prompt, and relationship data in Facets-owned model types.
+- Treat React Flow node/edge objects as view adapters derived from the Facets model.
+- Do not introduce side panels, modals, inspectors, or fullscreen editors until editing complexity proves they are needed.
+- Do not add OpenAI calls, API key management, agent execution, or direct Figma MCP execution in v1.
+
+## Validation
+
+For documentation-only work, verify links and issue references manually.
+
+For app work, run the relevant build/check commands documented by that issue. Once the Tauri scaffold exists, app PRs should at minimum document whether `npm run build` and the Tauri check/build path were run.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Facets
+
+Facets is a local-first Mac app for designers shaping prompts for AI-assisted design workflows.
+
+The restart direction is canvas-first: Facets v1 is a React Flow canvas of editable artifact nodes. Brief, Direction, and Prompt artifacts are edited directly on the canvas rather than through a side panel, inspector, modal, or fullscreen editor.
+
+## Product Stance
+
+- React Flow is the primary app surface for v1.
+- React Flow renders the canvas, but Facets owns the artifact/domain model.
+- Nodes are the primary editing interface.
+- Facets does not execute OpenAI calls, agent runs, or Figma MCP actions in v1.
+- Prompt nodes support manual copy for paste into ChatGPT, Codex, or ChatGPT sessions using the Figma MCP.
+
+Out of scope for v1: multi-canvas projects, collaboration, cloud sync, agent execution, direct API key management, and direct Figma MCP execution.
+
+## Workflow
+
+GitHub Issues are the source of truth for all work. Every implementation task should start from an issue, use an issue-numbered branch, and open a draft PR early.
+
+See:
+
+- [GitHub workflow](docs/github-workflow.md)
+- [Product direction](docs/product-direction.md)
+
+## Current Milestone
+
+The repo is being restarted from a docs-first foundation. The previous scaffold is preserved on the `archive/pre-restart-scaffold` branch.

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -1,0 +1,79 @@
+# GitHub Workflow
+
+Facets uses GitHub Issues as the source of truth. Local TODO documents should not replace issues.
+
+## Issue Types
+
+- `type:epic` - parent issue coordinating a body of work.
+- `type:task` - scoped implementation or documentation task.
+
+The restart epic is [#1](https://github.com/rschroed/Facet/issues/1): `Facets restart: canvas-first editable nodes`.
+
+## Labels
+
+Required labels:
+
+- `type:epic`
+- `type:task`
+- `area:docs`
+- `area:app`
+- `area:canvas`
+- `area:model`
+- `status:ready`
+- `status:in-progress`
+- `status:blocked`
+
+Use one `type:*` label, one or more `area:*` labels, and one `status:*` label.
+
+## Branches
+
+Use issue-numbered branches:
+
+```text
+issue-<number>-short-slug
+```
+
+Example:
+
+```text
+issue-2-github-workflow
+```
+
+Archive branches use:
+
+```text
+archive/<short-description>
+```
+
+The pre-restart scaffold is archived at `archive/pre-restart-scaffold`.
+
+## Pull Requests
+
+- Open a draft PR early for each issue branch.
+- Keep each PR scoped to one issue.
+- Link the issue in the PR body.
+- Use `Closes #<number>` only when the PR is ready to merge.
+- Include acceptance criteria copied or summarized from the issue.
+- Include validation notes, even for docs-only PRs.
+
+## Restart Issue Sequence
+
+1. [#2](https://github.com/rschroed/Facet/issues/2) - Document GitHub workflow.
+2. [#5](https://github.com/rschroed/Facet/issues/5) - Reset app scaffold around Tauri + React Flow.
+3. [#4](https://github.com/rschroed/Facet/issues/4) - Define Facets artifact model.
+4. [#3](https://github.com/rschroed/Facet/issues/3) - Define local project file shape.
+5. [#8](https://github.com/rschroed/Facet/issues/8) - Build static canvas with Brief, Direction, and Prompt nodes.
+6. [#7](https://github.com/rschroed/Facet/issues/7) - Add collapsed and expanded node editing states.
+7. [#6](https://github.com/rschroed/Facet/issues/6) - Add local project persistence.
+8. [#9](https://github.com/rschroed/Facet/issues/9) - Add prompt copy/export workflow.
+
+Issue numbers differ from the planned sequence because some issues were created in parallel. The sequence above is authoritative.
+
+## Acceptance Rules
+
+An issue is done when:
+
+- Its acceptance criteria are satisfied.
+- The PR links the issue.
+- Validation is documented in the PR.
+- The work does not introduce out-of-scope v1 behavior unless a later issue explicitly changes scope.

--- a/docs/product-direction.md
+++ b/docs/product-direction.md
@@ -1,0 +1,83 @@
+# Product Direction
+
+Facets v1 is a canvas-first prompt workbench for designers.
+
+The product starts as a React Flow canvas of editable artifact nodes. It is not a canvas plus inspector app. The main interaction should happen directly inside nodes on the canvas.
+
+## Core Artifacts
+
+Facets owns three artifact types:
+
+- `brief`
+- `direction`
+- `prompt`
+
+React Flow renders those artifacts, but React Flow node data is not the long-term source of truth.
+
+## Core Relationships
+
+Facets owns relationship types separately from React Flow edges:
+
+- `brief_to_direction`
+- `direction_to_prompt`
+- `prompt_sequence`
+
+React Flow edges are view objects derived from Facets relationships.
+
+## Node States
+
+Each artifact appears as a node with two states:
+
+- `collapsed` - compact scan mode showing type, title, short summary, and primary action.
+- `expanded` - editable mode showing the node's core fields directly on the canvas.
+
+## Initial Editable Fields
+
+Brief nodes:
+
+- project/problem title
+- short brief
+- audience
+- constraints
+
+Direction nodes:
+
+- direction title
+- angle
+- notes
+- optional rationale
+
+Prompt nodes:
+
+- prompt title
+- target
+- prompt summary
+- prompt text
+
+Prompt nodes include a copy action for manual paste into ChatGPT, Codex, or ChatGPT sessions using the Figma MCP.
+
+## Local-First Persistence
+
+Local persistence should save and load Facets project data, not raw React Flow state.
+
+Artifact content should remain separate from canvas rendering state. React Flow viewport and layout data may be saved alongside the artifact model, but should not become the source of truth for Brief, Direction, Prompt, or relationship content.
+
+## V1 Boundaries
+
+Facets v1 does not execute:
+
+- OpenAI calls
+- agent runs
+- direct Figma MCP actions
+- direct API key management
+
+Out of scope for v1:
+
+- multi-canvas projects
+- collaboration
+- cloud sync
+- agent execution
+- direct API key management
+- direct Figma MCP execution
+
+Side panels, modals, inspectors, and focus editors are deferred until real editing complexity requires them.


### PR DESCRIPTION
Issue: #2
Epic: #1

## Summary
- Adds the docs-first foundation for the Facets restart.
- Documents the GitHub issue, label, branch, and draft PR workflow.
- Captures the canvas-first editable-node product direction.
- Notes that the previous scaffold is archived on archive/pre-restart-scaffold.

## Acceptance criteria
- README.md describes the restart direction and links to workflow/product docs.
- AGENTS.md documents repo collaboration rules for future agents.
- docs/github-workflow.md defines issue, branch, PR, label, and acceptance rules.
- docs/product-direction.md captures the canvas-first editable-node product stance.
- The current scaffold has been archived before removal.
- A draft PR is opened for this docs/workflow foundation.

## Validation
- Verified the working tree contains only README.md, AGENTS.md, and docs/*.md for the foundation.
- No build command applies yet because this is a docs-only reset foundation.