### PR TITLE
Define Facets artifact model

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ See:
 
 - [GitHub workflow](docs/github-workflow.md)
 - [Product direction](docs/product-direction.md)
+- [Artifact model](docs/artifact-model.md)
 
 ## Current Milestone
 
 The repo is being restarted from a docs-first foundation. The previous scaffold is preserved on the `archive/pre-restart-scaffold` branch.
 
-Issue #5 adds the first app scaffold: a Tauri v2 + React + TypeScript shell with a full-window blank React Flow canvas. Product-specific node behavior starts in later issues.
+Issue #5 added the first app scaffold: a Tauri v2 + React + TypeScript shell with a full-window blank React Flow canvas. Issue #4 defines the first Facets artifact model. Product-specific node behavior starts in later issues.
 
 ## Development
 

--- a/docs/artifact-model.md
+++ b/docs/artifact-model.md
@@ -1,0 +1,85 @@
+# Artifact Model
+
+Facets owns the artifact model. React Flow renders that model on a canvas, but React Flow state is not the long-term source of truth.
+
+## Project and Canvas
+
+`FacetsProject` is the minimal project container for v1 model work:
+
+```ts
+type FacetsProject = {
+  id: ProjectId;
+  name: string;
+  canvas: FacetsCanvas;
+};
+
+type FacetsCanvas = {
+  id: CanvasId;
+  artifacts: FacetsArtifact[];
+  relationships: FacetsRelationship[];
+  nodeViews?: Record<ArtifactId, FacetsNodeViewState>;
+};
+
+type FacetsNodeViewState = {
+  expanded?: boolean;
+};
+```
+
+The canvas groups artifacts, relationships, and minimal node rendering state without defining the full local project file format.
+
+## Artifacts
+
+Facets has three artifact types:
+
+- `brief`
+- `direction`
+- `prompt`
+
+Each artifact is a discriminated TypeScript object with its own content fields:
+
+- Brief: `id`, `type`, `title`, `brief`, `audience`, `constraints`.
+- Direction: `id`, `type`, `title`, `angle`, `notes`, optional `rationale`.
+- Prompt: `id`, `type`, `title`, `target`, `summary`, `promptText`.
+
+Prompt targets are:
+
+```ts
+"chatgpt" | "codex" | "figma_mcp" | "generic"
+```
+
+## Relationships
+
+Relationships are Facets domain objects, not React Flow edges:
+
+```ts
+type FacetsRelationship = {
+  id: RelationshipId;
+  type: FacetsRelationshipType;
+  sourceId: ArtifactId;
+  targetId: ArtifactId;
+};
+```
+
+Relationship types are:
+
+- `brief_to_direction`
+- `direction_to_prompt`
+- `prompt_sequence`
+
+React Flow edges should be derived from these relationship objects.
+
+## React Flow Boundary
+
+Facets artifacts and relationships are the source of truth. React Flow nodes and edges are derived render objects.
+
+React Flow `node.data` can carry whatever a canvas component needs to render, but it must not become the long-term artifact store for Brief, Direction, Prompt, or relationship content.
+
+Collapsed and expanded node state is canvas rendering state, not artifact content. The initial model keeps this in `FacetsCanvas.nodeViews` so artifact content remains separate from view state.
+
+## Persistence Boundary
+
+Local persistence should later save and load `FacetsProject` data, not raw React Flow state.
+
+Viewport and layout data may be stored separately alongside the artifact model, but artifact content and relationships should remain independent from React Flow rendering state.
+
+The full project file format, including schema versioning, viewport/layout shape, timestamps, and save/load compatibility, remains deferred to issue #3.

--- a/docs/product-direction.md
+++ b/docs/product-direction.md
@@ -14,6 +14,8 @@ Facets owns three artifact types:
 
 React Flow renders those artifacts, but React Flow node data is not the long-term source of truth.
 
+See [Artifact model](artifact-model.md) for the initial TypeScript domain model and React Flow boundary.
+
 ## Core Relationships
 
 Facets owns relationship types separately from React Flow edges:
@@ -61,6 +63,8 @@ Prompt nodes include a copy action for manual paste into ChatGPT, Codex, or Chat
 Local persistence should save and load Facets project data, not raw React Flow state.
 
 Artifact content should remain separate from canvas rendering state. React Flow viewport and layout data may be saved alongside the artifact model, but should not become the source of truth for Brief, Direction, Prompt, or relationship content.
+
+The full local project file format remains deferred to issue #3.
 
 ## V1 Boundaries
 

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,0 +1,67 @@
+export type ProjectId = string;
+export type CanvasId = string;
+export type ArtifactId = string;
+export type RelationshipId = string;
+
+export type FacetsProject = {
+  id: ProjectId;
+  name: string;
+  canvas: FacetsCanvas;
+};
+
+export type FacetsCanvas = {
+  id: CanvasId;
+  artifacts: FacetsArtifact[];
+  relationships: FacetsRelationship[];
+  nodeViews?: Record<ArtifactId, FacetsNodeViewState>;
+};
+
+export type FacetsNodeViewState = {
+  expanded?: boolean;
+};
+
+export type BriefArtifact = {
+  id: ArtifactId;
+  type: "brief";
+  title: string;
+  brief: string;
+  audience: string;
+  constraints: string;
+};
+
+export type DirectionArtifact = {
+  id: ArtifactId;
+  type: "direction";
+  title: string;
+  angle: string;
+  notes: string;
+  rationale?: string;
+};
+
+export type PromptTarget = "chatgpt" | "codex" | "figma_mcp" | "generic";
+
+export type PromptArtifact = {
+  id: ArtifactId;
+  type: "prompt";
+  title: string;
+  target: PromptTarget;
+  summary: string;
+  promptText: string;
+};
+
+export type FacetsArtifact =
+  | BriefArtifact
+  | DirectionArtifact
+  | PromptArtifact;
+
+export type FacetsRelationshipType =
+  | "brief_to_direction"
+  | "direction_to_prompt"
+  | "prompt_sequence";
+
+export type FacetsRelationship = {
+  id: RelationshipId;
+  type: FacetsRelationshipType;
+  sourceId: ArtifactId;
+  targetId: ArtifactId;
+};


### PR DESCRIPTION
Issue: #4
Epic: #1

## Summary
- Adds the initial TypeScript Facets domain model under src/domain/.
- Defines Brief, Direction, and Prompt artifacts as discriminated unions.
- Defines relationships separately from React Flow edges.
- Documents the React Flow boundary and persistence boundary in docs/artifact-model.md.

## Acceptance criteria
- Brief, Direction, and Prompt artifact types are defined.
- Relationship types are defined separately from React Flow edges.
- Conversion between Facets artifacts and React Flow nodes/edges is documented or implemented.

## Explicitly not included
- UI nodes or custom React Flow node behavior.
- Persistence or local project file format details.
- Prompt copy/export behavior.
- Helper implementation or React Flow state mutation.
- Model-provider behavior, agent execution, or Figma MCP behavior.

## Validation
- npm run build passed.
- Confirmed changed files are limited to TypeScript domain types and documentation.
- React Flow conversion boundary is documented rather than implemented for this issue.