### PR TITLE
Define local project file shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ See:
 - [GitHub workflow](docs/github-workflow.md)
 - [Product direction](docs/product-direction.md)
 - [Artifact model](docs/artifact-model.md)
+- [Local project file](docs/local-project-file.md)
 
 ## Current Milestone
 
 The repo is being restarted from a docs-first foundation. The previous scaffold is preserved on the `archive/pre-restart-scaffold` branch.
 
-Issue #5 added the first app scaffold: a Tauri v2 + React + TypeScript shell with a full-window blank React Flow canvas. Issue #4 defines the first Facets artifact model. Product-specific node behavior starts in later issues.
+Issue #5 added the first app scaffold: a Tauri v2 + React + TypeScript shell with a full-window blank React Flow canvas. Issue #4 defined the first Facets artifact model. Issue #3 defines the local `.facets.json` file shape. Product-specific node behavior starts in later issues.
 
 ## Development
 

--- a/docs/artifact-model.md
+++ b/docs/artifact-model.md
@@ -17,15 +17,10 @@ type FacetsCanvas = {
   id: CanvasId;
   artifacts: FacetsArtifact[];
   relationships: FacetsRelationship[];
-  nodeViews?: Record<ArtifactId, FacetsNodeViewState>;
-};
-
-type FacetsNodeViewState = {
-  expanded?: boolean;
 };
 ```
 
-The canvas groups artifacts, relationships, and minimal node rendering state without defining the full local project file format.
+The canvas groups artifact and relationship content. Local project files store canvas rendering state separately.
 
 ## Artifacts
 
@@ -74,7 +69,7 @@ Facets artifacts and relationships are the source of truth. React Flow nodes and
 
 React Flow `node.data` can carry whatever a canvas component needs to render, but it must not become the long-term artifact store for Brief, Direction, Prompt, or relationship content.
 
-Collapsed and expanded node state is canvas rendering state, not artifact content. The initial model keeps this in `FacetsCanvas.nodeViews` so artifact content remains separate from view state.
+Collapsed and expanded node state is canvas rendering state, not artifact content. Local project files keep this state outside `FacetsProject.canvas` so artifact content remains separate from view state.
 
 ## Persistence Boundary
 
@@ -82,4 +77,4 @@ Local persistence should later save and load `FacetsProject` data, not raw React
 
 Viewport and layout data may be stored separately alongside the artifact model, but artifact content and relationships should remain independent from React Flow rendering state.
 
-The full project file format, including schema versioning, viewport/layout shape, timestamps, and save/load compatibility, remains deferred to issue #3.
+See [Local project file](local-project-file.md) for the `.facets.json` wrapper and canvas view shape. Save/load behavior remains deferred to a later issue.

--- a/docs/local-project-file.md
+++ b/docs/local-project-file.md
@@ -1,0 +1,179 @@
+# Local Project File
+
+Facets project files use plain JSON with the `.facets.json` extension.
+
+The file format is local-first. It stores Facets project data and canvas rendering state in one file without requiring cloud sync, accounts, collaboration, or hosted services.
+
+## File Shape
+
+A local project file has a versioned wrapper:
+
+```ts
+type FacetsProjectFile = {
+  app: "facets";
+  schemaVersion: 1;
+  project: FacetsProject;
+  canvasView: FacetsCanvasView;
+};
+```
+
+`project` stores Facets domain data. `canvasView` stores canvas rendering state.
+
+The project model remains focused on artifact and relationship content:
+
+```ts
+type FacetsProject = {
+  id: ProjectId;
+  name: string;
+  canvas: FacetsCanvas;
+};
+
+type FacetsCanvas = {
+  id: CanvasId;
+  artifacts: FacetsArtifact[];
+  relationships: FacetsRelationship[];
+};
+```
+
+Canvas rendering state is stored separately:
+
+```ts
+type FacetsCanvasView = {
+  canvasId: CanvasId;
+  viewport: FacetsCanvasViewport;
+  nodes: Record<ArtifactId, FacetsCanvasNodeView>;
+};
+
+type FacetsCanvasViewport = {
+  x: number;
+  y: number;
+  zoom: number;
+};
+
+type FacetsCanvasNodeView = {
+  expanded?: boolean;
+  position: FacetsCanvasNodePosition;
+  size?: FacetsCanvasNodeSize;
+};
+
+type FacetsCanvasNodePosition = {
+  x: number;
+  y: number;
+};
+
+type FacetsCanvasNodeSize = {
+  width: number;
+  height: number;
+};
+```
+
+`canvasView.canvasId` must reference `project.canvas.id`.
+
+## React Flow Boundary
+
+React Flow nodes are derived from `project.canvas.artifacts` plus `canvasView.nodes`.
+
+React Flow edges are derived from `project.canvas.relationships`.
+
+React Flow viewport is derived from `canvasView.viewport`.
+
+Raw React Flow state should not be serialized as the Facets project file format. React Flow can provide useful rendering details, but the saved file should preserve the Facets domain model and the minimum canvas view state needed to restore the workbench.
+
+Artifact content lives in `project.canvas.artifacts`. Relationship content lives in `project.canvas.relationships`. Viewport, position, size, and expanded state live in `canvasView`.
+
+## Example
+
+The example below is illustrative documentation, not a committed sample file or runtime fixture.
+
+```json
+{
+  "app": "facets",
+  "schemaVersion": 1,
+  "project": {
+    "id": "project-1",
+    "name": "Homepage exploration",
+    "canvas": {
+      "id": "canvas-1",
+      "artifacts": [
+        {
+          "id": "brief-1",
+          "type": "brief",
+          "title": "Homepage concept",
+          "brief": "Explore a clearer homepage direction for a design tooling product.",
+          "audience": "Product designers and design leaders",
+          "constraints": "Keep the page practical, local-first, and focused on prompt quality."
+        },
+        {
+          "id": "direction-1",
+          "type": "direction",
+          "title": "Workbench canvas",
+          "angle": "Show the design process as connected editable artifacts.",
+          "notes": "Use a lightweight canvas with brief, direction, and prompt nodes.",
+          "rationale": "The structure makes iteration visible without introducing workflow overhead."
+        },
+        {
+          "id": "prompt-1",
+          "type": "prompt",
+          "title": "Generate first concept",
+          "target": "chatgpt",
+          "summary": "Ask an agent to create a first homepage concept from the selected direction.",
+          "promptText": "Create a homepage concept in Figma based on the brief and workbench canvas direction."
+        }
+      ],
+      "relationships": [
+        {
+          "id": "relationship-1",
+          "type": "brief_to_direction",
+          "sourceId": "brief-1",
+          "targetId": "direction-1"
+        },
+        {
+          "id": "relationship-2",
+          "type": "direction_to_prompt",
+          "sourceId": "direction-1",
+          "targetId": "prompt-1"
+        }
+      ]
+    }
+  },
+  "canvasView": {
+    "canvasId": "canvas-1",
+    "viewport": {
+      "x": 0,
+      "y": 0,
+      "zoom": 1
+    },
+    "nodes": {
+      "brief-1": {
+        "expanded": true,
+        "position": {
+          "x": 0,
+          "y": 0
+        },
+        "size": {
+          "width": 320,
+          "height": 240
+        }
+      },
+      "direction-1": {
+        "position": {
+          "x": 420,
+          "y": 0
+        }
+      },
+      "prompt-1": {
+        "position": {
+          "x": 840,
+          "y": 0
+        }
+      }
+    }
+  }
+}
+```
+
+## Deferred Work
+
+This file shape does not implement save/load behavior, file dialogs, migrations, React Flow adapters, prompt export, or runtime persistence.
+
+The v1 local file contract does not include timestamps. Future issues can add migration behavior when a future `schemaVersion` is introduced.

--- a/docs/product-direction.md
+++ b/docs/product-direction.md
@@ -64,7 +64,7 @@ Local persistence should save and load Facets project data, not raw React Flow s
 
 Artifact content should remain separate from canvas rendering state. React Flow viewport and layout data may be saved alongside the artifact model, but should not become the source of truth for Brief, Direction, Prompt, or relationship content.
 
-The full local project file format remains deferred to issue #3.
+See [Local project file](local-project-file.md) for the documented `.facets.json` shape.
 
 ## V1 Boundaries
 

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -13,11 +13,41 @@ export type FacetsCanvas = {
   id: CanvasId;
   artifacts: FacetsArtifact[];
   relationships: FacetsRelationship[];
-  nodeViews?: Record<ArtifactId, FacetsNodeViewState>;
 };
 
-export type FacetsNodeViewState = {
+export type FacetsProjectFile = {
+  app: "facets";
+  schemaVersion: 1;
+  project: FacetsProject;
+  canvasView: FacetsCanvasView;
+};
+
+export type FacetsCanvasView = {
+  canvasId: CanvasId;
+  viewport: FacetsCanvasViewport;
+  nodes: Record<ArtifactId, FacetsCanvasNodeView>;
+};
+
+export type FacetsCanvasViewport = {
+  x: number;
+  y: number;
+  zoom: number;
+};
+
+export type FacetsCanvasNodeView = {
   expanded?: boolean;
+  position: FacetsCanvasNodePosition;
+  size?: FacetsCanvasNodeSize;
+};
+
+export type FacetsCanvasNodePosition = {
+  x: number;
+  y: number;
+};
+
+export type FacetsCanvasNodeSize = {
+  width: number;
+  height: number;
 };
 
 export type BriefArtifact = {


### PR DESCRIPTION
Issue: #3
Epic: #1

## Summary
- Defines the .facets.json local project file wrapper with app, schemaVersion, project, and canvasView.
- Removes rendering state from the FacetsCanvas domain model so artifacts and relationships stay separate from view state.
- Adds file-shape TypeScript types for canvas viewport and per-node rendering state.
- Documents the project file format and React Flow serialization boundary in docs/local-project-file.md.

## Acceptance criteria
- The local project file structure is documented.
- Artifact content is stored separately from React Flow rendering state.
- Canvas viewport/layout data may be stored alongside the artifact model.
- The format supports future local save/load without requiring cloud sync or accounts.

## Explicitly not included
- Save/load commands or filesystem access.
- Runtime persistence or migrations.
- UI nodes or React Flow adapters/helpers.
- Prompt copy/export behavior.
- Model-provider behavior, agent execution, or Figma MCP behavior.

## Validation
- npm run build passed.
- Confirmed artifact and relationship content lives under project.canvas.
- Confirmed viewport, position, size, and expanded state live under sibling canvasView.
- Confirmed raw React Flow state is documented as outside the project file format.