### PR TITLE
Build static artifact canvas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,30 @@
-import { Background, Controls, ReactFlow } from "@xyflow/react";
+import { Background, Controls, ReactFlow, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import ArtifactNode from "./canvas/ArtifactNode";
+import { mapProjectFileToReactFlow } from "./canvas/mapFacetsToReactFlow";
+import { staticProjectFile } from "./fixtures/staticProject";
 import "./styles.css";
+
+const nodeTypes = {
+  artifact: ArtifactNode,
+} satisfies NodeTypes;
+
+const staticGraph = mapProjectFileToReactFlow(staticProjectFile);
 
 function App() {
   return (
     <main className="app-shell" aria-label="Facets canvas">
-      <ReactFlow nodes={[]} edges={[]} fitView>
+      <ReactFlow
+        nodes={staticGraph.nodes}
+        edges={staticGraph.edges}
+        nodeTypes={nodeTypes}
+        fitView
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        edgesReconnectable={false}
+        deleteKeyCode={null}
+      >
         <Background />
         <Controls />
       </ReactFlow>

--- a/src/canvas/ArtifactNode.tsx
+++ b/src/canvas/ArtifactNode.tsx
@@ -1,0 +1,17 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import type { ArtifactNode as ArtifactNodeType } from "./types";
+
+function ArtifactNode({ data }: NodeProps<ArtifactNodeType>) {
+  return (
+    <article className={`artifact-node artifact-node--${data.artifact.type}`}>
+      <Handle type="target" position={Position.Left} isConnectable={false} />
+      <div className="artifact-node__eyebrow">{data.typeLabel}</div>
+      <h2 className="artifact-node__title">{data.artifact.title}</h2>
+      <p className="artifact-node__summary">{data.summary}</p>
+      <p className="artifact-node__detail">{data.detail}</p>
+      <Handle type="source" position={Position.Right} isConnectable={false} />
+    </article>
+  );
+}
+
+export default ArtifactNode;

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -1,0 +1,110 @@
+import type {
+  FacetsArtifact,
+  FacetsProjectFile,
+  FacetsRelationship,
+  PromptTarget,
+} from "../domain";
+import type { ArtifactNode, ArtifactNodeData, RelationshipEdge } from "./types";
+
+export type FacetsReactFlowGraph = {
+  nodes: ArtifactNode[];
+  edges: RelationshipEdge[];
+};
+
+export function mapProjectFileToReactFlow(
+  projectFile: FacetsProjectFile,
+): FacetsReactFlowGraph {
+  return {
+    nodes: projectFile.project.canvas.artifacts.map((artifact) =>
+      mapArtifactToNode(artifact, projectFile),
+    ),
+    edges: projectFile.project.canvas.relationships.map(mapRelationshipToEdge),
+  };
+}
+
+function mapArtifactToNode(
+  artifact: FacetsArtifact,
+  projectFile: FacetsProjectFile,
+): ArtifactNode {
+  const nodeView = projectFile.canvasView.nodes[artifact.id];
+
+  return {
+    id: artifact.id,
+    type: "artifact",
+    position: nodeView.position,
+    data: getArtifactNodeData(artifact),
+    draggable: false,
+    selectable: false,
+    style: nodeView.size
+      ? {
+          width: nodeView.size.width,
+          minHeight: nodeView.size.height,
+        }
+      : undefined,
+  };
+}
+
+function getArtifactNodeData(artifact: FacetsArtifact): ArtifactNodeData {
+  switch (artifact.type) {
+    case "brief":
+      return {
+        artifact,
+        typeLabel: "Brief",
+        summary: artifact.brief,
+        detail: artifact.audience,
+      };
+    case "direction":
+      return {
+        artifact,
+        typeLabel: "Direction",
+        summary: artifact.angle,
+        detail: artifact.notes,
+      };
+    case "prompt":
+      return {
+        artifact,
+        typeLabel: "Prompt",
+        summary: artifact.summary,
+        detail: getPromptTargetLabel(artifact.target),
+      };
+  }
+}
+
+function mapRelationshipToEdge(
+  relationship: FacetsRelationship,
+): RelationshipEdge {
+  return {
+    id: relationship.id,
+    type: "smoothstep",
+    source: relationship.sourceId,
+    target: relationship.targetId,
+    label: getRelationshipLabel(relationship),
+    data: { relationship },
+    selectable: false,
+    reconnectable: false,
+  };
+}
+
+function getRelationshipLabel(relationship: FacetsRelationship): string {
+  switch (relationship.type) {
+    case "brief_to_direction":
+      return "Direction";
+    case "direction_to_prompt":
+      return "Prompt";
+    case "prompt_sequence":
+      return "Sequence";
+  }
+}
+
+function getPromptTargetLabel(target: PromptTarget): string {
+  switch (target) {
+    case "chatgpt":
+      return "ChatGPT";
+    case "codex":
+      return "Codex";
+    case "figma_mcp":
+      return "Figma MCP";
+    case "generic":
+      return "Generic";
+  }
+}

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -1,0 +1,17 @@
+import type { Edge, Node } from "@xyflow/react";
+import type { FacetsArtifact, FacetsRelationship } from "../domain";
+
+export type ArtifactNodeData = {
+  artifact: FacetsArtifact;
+  typeLabel: string;
+  summary: string;
+  detail: string;
+};
+
+export type ArtifactNode = Node<ArtifactNodeData, "artifact">;
+
+export type RelationshipEdgeData = {
+  relationship: FacetsRelationship;
+};
+
+export type RelationshipEdge = Edge<RelationshipEdgeData, "smoothstep">;

--- a/src/fixtures/staticProject.ts
+++ b/src/fixtures/staticProject.ts
@@ -1,0 +1,85 @@
+import type { FacetsProjectFile } from "../domain";
+
+export const staticProjectFile: FacetsProjectFile = {
+  app: "facets",
+  schemaVersion: 1,
+  project: {
+    id: "project-static-homepage",
+    name: "Homepage exploration",
+    canvas: {
+      id: "canvas-static-homepage",
+      artifacts: [
+        {
+          id: "brief-static-homepage",
+          type: "brief",
+          title: "Homepage concept",
+          brief:
+            "Explore a clearer homepage direction for a local-first prompt workbench.",
+          audience: "Product designers and design leaders",
+          constraints:
+            "Keep it practical, canvas-first, and focused on better prompts for design agents.",
+        },
+        {
+          id: "direction-static-workbench",
+          type: "direction",
+          title: "Workbench canvas",
+          angle:
+            "Show the design process as connected editable artifacts instead of a form-heavy workflow.",
+          notes:
+            "Lead with a simple canvas that makes the path from brief to direction to prompt visible.",
+          rationale:
+            "The structure helps designers guide agent work without turning Facets into an execution tool.",
+        },
+        {
+          id: "prompt-static-first-concept",
+          type: "prompt",
+          title: "Generate first concept",
+          target: "chatgpt",
+          summary:
+            "Ask an external agent to create a first Figma concept from the selected direction.",
+          promptText:
+            "Create a homepage concept in Figma based on the brief and workbench canvas direction.",
+        },
+      ],
+      relationships: [
+        {
+          id: "relationship-static-brief-direction",
+          type: "brief_to_direction",
+          sourceId: "brief-static-homepage",
+          targetId: "direction-static-workbench",
+        },
+        {
+          id: "relationship-static-direction-prompt",
+          type: "direction_to_prompt",
+          sourceId: "direction-static-workbench",
+          targetId: "prompt-static-first-concept",
+        },
+      ],
+    },
+  },
+  canvasView: {
+    canvasId: "canvas-static-homepage",
+    viewport: {
+      x: 0,
+      y: 0,
+      zoom: 1,
+    },
+    nodes: {
+      "brief-static-homepage": {
+        expanded: false,
+        position: { x: 0, y: 0 },
+        size: { width: 320, height: 220 },
+      },
+      "direction-static-workbench": {
+        expanded: false,
+        position: { x: 440, y: 0 },
+        size: { width: 340, height: 220 },
+      },
+      "prompt-static-first-concept": {
+        expanded: false,
+        position: { x: 900, y: 0 },
+        size: { width: 340, height: 220 },
+      },
+    },
+  },
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -31,7 +31,100 @@ body {
   background: #f6f2e8;
 }
 
+.react-flow__pane {
+  cursor: grab;
+}
+
+.react-flow__pane:active {
+  cursor: grabbing;
+}
+
 .react-flow__controls {
   border: 1px solid rgba(31, 35, 32, 0.12);
   box-shadow: 0 16px 40px rgba(54, 48, 36, 0.08);
+}
+
+.react-flow__edge-path {
+  stroke: #81786a;
+  stroke-width: 1.6;
+}
+
+.react-flow__edge-textbg {
+  fill: #f6f2e8;
+}
+
+.react-flow__edge-text {
+  fill: #5f594f;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.artifact-node {
+  width: 100%;
+  min-height: 210px;
+  padding: 20px;
+  color: #24251f;
+  background: #fffdf7;
+  border: 1px solid rgba(31, 35, 32, 0.14);
+  border-radius: 8px;
+  box-shadow: 0 18px 48px rgba(54, 48, 36, 0.12);
+}
+
+.artifact-node--brief {
+  border-color: rgba(31, 124, 96, 0.34);
+}
+
+.artifact-node--direction {
+  border-color: rgba(88, 99, 131, 0.3);
+}
+
+.artifact-node--prompt {
+  border-color: rgba(146, 94, 55, 0.3);
+}
+
+.artifact-node__eyebrow {
+  margin-bottom: 12px;
+  color: #1f7c60;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.artifact-node--direction .artifact-node__eyebrow {
+  color: #586383;
+}
+
+.artifact-node--prompt .artifact-node__eyebrow {
+  color: #925e37;
+}
+
+.artifact-node__title {
+  margin: 0;
+  color: #1f211d;
+  font-size: 22px;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.artifact-node__summary {
+  margin: 14px 0 0;
+  color: #4f4a42;
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.artifact-node__detail {
+  margin: 16px 0 0;
+  color: #766f63;
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.artifact-node .react-flow__handle {
+  width: 9px;
+  height: 9px;
+  background: #f6f2e8;
+  border: 2px solid #81786a;
 }


### PR DESCRIPTION
Issue: #8
Epic: #1

## Summary
- Renders one Brief node, one Direction node, and one Prompt node on the React Flow canvas.
- Adds a typed static FacetsProjectFile fixture for the first canvas view.
- Adds a small React Flow mapper that derives nodes from artifacts plus canvasView nodes, and edges from Facets relationships.
- Adds readonly artifact node cards with static handles and relationship edge labels.

## Acceptance criteria
- React Flow renders one Brief node, one Direction node, and one Prompt node.
- Nodes are backed by Facets artifact objects.
- Relationships render as canvas edges derived from Facets relationship objects.
- The canvas works without persistence or model/API calls.

## Explicitly not included
- Node editing, collapsed/expanded toggles, or prompt copy/export.
- Save/load, filesystem access, runtime persistence, or migrations.
- Model/API calls, agent execution, or Figma MCP behavior.
- React Flow dependencies inside src/domain.

## Validation
- npm run build passed.
- git diff --check passed.
- Confirmed src/domain has no React or @xyflow/react imports.
- Dev server started at http://127.0.0.1:1420/ and returned HTTP 200.
- Vite served the transformed App and static fixture modules.
- Production bundle contains the three artifact titles and relationship IDs.
- Browser automation/screenshot verification was attempted, but the available Playwright backend was closed and Computer Use permissions were not granted in this session.