### PR TITLE
Add collapsed and expanded node states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
+import { useCallback, useMemo, useState } from "react";
 import { Background, Controls, ReactFlow, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import ArtifactNode from "./canvas/ArtifactNode";
 import { mapProjectFileToReactFlow } from "./canvas/mapFacetsToReactFlow";
+import type { ArtifactId } from "./domain";
 import { staticProjectFile } from "./fixtures/staticProject";
 import "./styles.css";
 
@@ -9,9 +11,35 @@ const nodeTypes = {
   artifact: ArtifactNode,
 } satisfies NodeTypes;
 
-const staticGraph = mapProjectFileToReactFlow(staticProjectFile);
-
 function App() {
+  const [canvasView, setCanvasView] = useState(staticProjectFile.canvasView);
+
+  const handleToggleExpanded = useCallback((artifactId: ArtifactId) => {
+    setCanvasView((currentCanvasView) => {
+      const currentNodeView = currentCanvasView.nodes[artifactId];
+
+      return {
+        ...currentCanvasView,
+        nodes: {
+          ...currentCanvasView.nodes,
+          [artifactId]: {
+            ...currentNodeView,
+            expanded: !currentNodeView.expanded,
+          },
+        },
+      };
+    });
+  }, []);
+
+  const staticGraph = useMemo(
+    () =>
+      mapProjectFileToReactFlow(staticProjectFile, {
+        canvasView,
+        onToggleExpanded: handleToggleExpanded,
+      }),
+    [canvasView, handleToggleExpanded],
+  );
+
   return (
     <main className="app-shell" aria-label="Facets canvas">
       <ReactFlow
@@ -21,7 +49,7 @@ function App() {
         fitView
         nodesDraggable={false}
         nodesConnectable={false}
-        elementsSelectable={false}
+        elementsSelectable
         edgesReconnectable={false}
         deleteKeyCode={null}
       >

--- a/src/canvas/ArtifactNode.tsx
+++ b/src/canvas/ArtifactNode.tsx
@@ -1,16 +1,93 @@
+import type { MouseEvent } from "react";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { getPromptTargetLabel } from "./mapFacetsToReactFlow";
 import type { ArtifactNode as ArtifactNodeType } from "./types";
 
 function ArtifactNode({ data }: NodeProps<ArtifactNodeType>) {
+  const toggleLabel = data.expanded ? "Collapse" : "Expand";
+
+  function handleToggleClick(event: MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+    data.onToggleExpanded?.(data.artifact.id);
+  }
+
   return (
-    <article className={`artifact-node artifact-node--${data.artifact.type}`}>
+    <article
+      className={[
+        "artifact-node",
+        `artifact-node--${data.artifact.type}`,
+        data.expanded ? "artifact-node--expanded" : "artifact-node--collapsed",
+      ].join(" ")}
+    >
       <Handle type="target" position={Position.Left} isConnectable={false} />
-      <div className="artifact-node__eyebrow">{data.typeLabel}</div>
+      <header className="artifact-node__header">
+        <div className="artifact-node__eyebrow">{data.typeLabel}</div>
+        <button
+          className="artifact-node__action nodrag nopan"
+          type="button"
+          onClick={handleToggleClick}
+        >
+          {toggleLabel}
+        </button>
+      </header>
       <h2 className="artifact-node__title">{data.artifact.title}</h2>
-      <p className="artifact-node__summary">{data.summary}</p>
-      <p className="artifact-node__detail">{data.detail}</p>
+      {data.expanded ? (
+        <ExpandedArtifactFields artifact={data.artifact} />
+      ) : (
+        <p className="artifact-node__summary">{data.summary}</p>
+      )}
       <Handle type="source" position={Position.Right} isConnectable={false} />
     </article>
+  );
+}
+
+function ExpandedArtifactFields({
+  artifact,
+}: Pick<ArtifactNodeType["data"], "artifact">) {
+  switch (artifact.type) {
+    case "brief":
+      return (
+        <dl className="artifact-node__fields">
+          <ReadonlyField label="Brief" value={artifact.brief} />
+          <ReadonlyField label="Audience" value={artifact.audience} />
+          <ReadonlyField label="Constraints" value={artifact.constraints} />
+        </dl>
+      );
+    case "direction":
+      return (
+        <dl className="artifact-node__fields">
+          <ReadonlyField label="Angle" value={artifact.angle} />
+          <ReadonlyField label="Notes" value={artifact.notes} />
+          {artifact.rationale ? (
+            <ReadonlyField label="Rationale" value={artifact.rationale} />
+          ) : null}
+        </dl>
+      );
+    case "prompt":
+      return (
+        <dl className="artifact-node__fields">
+          <ReadonlyField
+            label="Target"
+            value={getPromptTargetLabel(artifact.target)}
+          />
+          <ReadonlyField label="Summary" value={artifact.summary} />
+          <ReadonlyField label="Prompt text" value={artifact.promptText} />
+        </dl>
+      );
+  }
+}
+
+type ReadonlyFieldProps = {
+  label: string;
+  value: string;
+};
+
+function ReadonlyField({ label, value }: ReadonlyFieldProps) {
+  return (
+    <div className="artifact-node__field">
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </div>
   );
 }
 

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -1,4 +1,6 @@
 import type {
+  ArtifactId,
+  FacetsCanvasView,
   FacetsArtifact,
   FacetsProjectFile,
   FacetsRelationship,
@@ -11,12 +13,20 @@ export type FacetsReactFlowGraph = {
   edges: RelationshipEdge[];
 };
 
+export type MapProjectFileToReactFlowOptions = {
+  canvasView?: FacetsCanvasView;
+  onToggleExpanded?: (artifactId: ArtifactId) => void;
+};
+
 export function mapProjectFileToReactFlow(
   projectFile: FacetsProjectFile,
+  options: MapProjectFileToReactFlowOptions = {},
 ): FacetsReactFlowGraph {
+  const canvasView = options.canvasView ?? projectFile.canvasView;
+
   return {
     nodes: projectFile.project.canvas.artifacts.map((artifact) =>
-      mapArtifactToNode(artifact, projectFile),
+      mapArtifactToNode(artifact, canvasView, options.onToggleExpanded),
     ),
     edges: projectFile.project.canvas.relationships.map(mapRelationshipToEdge),
   };
@@ -24,17 +34,23 @@ export function mapProjectFileToReactFlow(
 
 function mapArtifactToNode(
   artifact: FacetsArtifact,
-  projectFile: FacetsProjectFile,
+  canvasView: FacetsCanvasView,
+  onToggleExpanded?: (artifactId: ArtifactId) => void,
 ): ArtifactNode {
-  const nodeView = projectFile.canvasView.nodes[artifact.id];
+  const nodeView = canvasView.nodes[artifact.id];
 
   return {
     id: artifact.id,
     type: "artifact",
     position: nodeView.position,
-    data: getArtifactNodeData(artifact),
+    data: getArtifactNodeData(
+      artifact,
+      Boolean(nodeView.expanded),
+      onToggleExpanded,
+    ),
     draggable: false,
     selectable: false,
+    zIndex: 2,
     style: nodeView.size
       ? {
           width: nodeView.size.width,
@@ -44,28 +60,35 @@ function mapArtifactToNode(
   };
 }
 
-function getArtifactNodeData(artifact: FacetsArtifact): ArtifactNodeData {
+function getArtifactNodeData(
+  artifact: FacetsArtifact,
+  expanded: boolean,
+  onToggleExpanded?: (artifactId: ArtifactId) => void,
+): ArtifactNodeData {
   switch (artifact.type) {
     case "brief":
       return {
         artifact,
         typeLabel: "Brief",
         summary: artifact.brief,
-        detail: artifact.audience,
+        expanded,
+        onToggleExpanded,
       };
     case "direction":
       return {
         artifact,
         typeLabel: "Direction",
         summary: artifact.angle,
-        detail: artifact.notes,
+        expanded,
+        onToggleExpanded,
       };
     case "prompt":
       return {
         artifact,
         typeLabel: "Prompt",
         summary: artifact.summary,
-        detail: getPromptTargetLabel(artifact.target),
+        expanded,
+        onToggleExpanded,
       };
   }
 }
@@ -96,7 +119,7 @@ function getRelationshipLabel(relationship: FacetsRelationship): string {
   }
 }
 
-function getPromptTargetLabel(target: PromptTarget): string {
+export function getPromptTargetLabel(target: PromptTarget): string {
   switch (target) {
     case "chatgpt":
       return "ChatGPT";

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -1,11 +1,12 @@
 import type { Edge, Node } from "@xyflow/react";
-import type { FacetsArtifact, FacetsRelationship } from "../domain";
+import type { ArtifactId, FacetsArtifact, FacetsRelationship } from "../domain";
 
 export type ArtifactNodeData = {
   artifact: FacetsArtifact;
   typeLabel: string;
   summary: string;
-  detail: string;
+  expanded: boolean;
+  onToggleExpanded?: (artifactId: ArtifactId) => void;
 };
 
 export type ArtifactNode = Node<ArtifactNodeData, "artifact">;

--- a/src/styles.css
+++ b/src/styles.css
@@ -60,6 +60,16 @@ body {
   letter-spacing: 0;
 }
 
+.react-flow__node {
+  z-index: 2;
+  pointer-events: all !important;
+}
+
+.artifact-node,
+.artifact-node__action {
+  pointer-events: auto;
+}
+
 .artifact-node {
   width: 100%;
   min-height: 210px;
@@ -69,6 +79,14 @@ body {
   border: 1px solid rgba(31, 35, 32, 0.14);
   border-radius: 8px;
   box-shadow: 0 18px 48px rgba(54, 48, 36, 0.12);
+}
+
+.artifact-node--collapsed {
+  min-height: 210px;
+}
+
+.artifact-node--expanded {
+  min-height: 300px;
 }
 
 .artifact-node--brief {
@@ -83,8 +101,16 @@ body {
   border-color: rgba(146, 94, 55, 0.3);
 }
 
+.artifact-node__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 28px;
+  margin-bottom: 14px;
+}
+
 .artifact-node__eyebrow {
-  margin-bottom: 12px;
   color: #1f7c60;
   font-size: 12px;
   font-weight: 800;
@@ -115,11 +141,57 @@ body {
   line-height: 1.45;
 }
 
-.artifact-node__detail {
-  margin: 16px 0 0;
-  color: #766f63;
+.artifact-node__fields {
+  display: grid;
+  gap: 14px;
+  margin: 18px 0 0;
+}
+
+.artifact-node__field {
+  display: grid;
+  gap: 5px;
+}
+
+.artifact-node__field dt {
+  color: #81786a;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.artifact-node__field dd {
+  margin: 0;
+  color: #4f4a42;
   font-size: 13px;
-  line-height: 1.35;
+  line-height: 1.42;
+}
+
+.artifact-node__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  min-height: 28px;
+  padding: 0 11px;
+  color: #1f211d;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  background: #f6f2e8;
+  border: 1px solid rgba(31, 35, 32, 0.16);
+  border-radius: 7px;
+  cursor: pointer;
+}
+
+.artifact-node__action:hover {
+  background: #eee8d9;
+}
+
+.artifact-node__action:focus-visible {
+  outline: 3px solid rgba(31, 124, 96, 0.24);
+  outline-offset: 2px;
 }
 
 .artifact-node .react-flow__handle {


### PR DESCRIPTION
Issue: #15
Epic: #1
Split from: #7

## Summary
- Adds in-memory expanded/collapsed state for artifact nodes using FacetsCanvasView in App.tsx.
- Keeps artifact content unchanged; toggling updates canvasView.nodes[artifactId].expanded only.
- Updates the React Flow mapper to pass expanded state and a toggle callback into node render data.
- Adds readonly collapsed and expanded layouts for Brief, Direction, and Prompt nodes.

## Acceptance criteria
- Brief, Direction, and Prompt nodes can toggle between collapsed and expanded states.
- Collapsed state remains a compact scan view with type, title, summary, and an Expand button.
- Expanded state is readonly and shows the core fields for each artifact type.
- Expanded/collapsed state is held in canvas view state, not artifact content.
- No inspector, side panel, modal, fullscreen editor, persistence, prompt copy/export, model/API calls, or Figma MCP behavior is introduced.

## Explicitly not included
- Editable fields.
- Save/load, filesystem access, runtime persistence, or migrations.
- Prompt copy/export behavior.
- Model/API calls, agent execution, or Figma MCP behavior.
- React or @xyflow/react dependencies inside src/domain.

## Validation
- npm run build passed.
- git diff --check passed.
- Dev server started at http://127.0.0.1:1420/ and returned HTTP 200.
- Playwright loaded the app with title Facets and reported 0 console errors.
- Playwright verified Brief expands to readonly Brief, Audience, and Constraints fields and collapses back to summary-only scan state.
- Playwright verified Direction expands to readonly Angle, Notes, and Rationale fields.
- Playwright verified Prompt expands to readonly Target, Summary, and Prompt text fields.
- Confirmed collapsed nodes show no extra detail field.
- Confirmed src/domain has no React or @xyflow/react imports.