### PR TITLE
Add editable Brief node fields

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Background, Controls, ReactFlow, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import ArtifactNode from "./canvas/ArtifactNode";
 import { mapProjectFileToReactFlow } from "./canvas/mapFacetsToReactFlow";
+import type { BriefArtifactPatch } from "./canvas/types";
 import type { ArtifactId } from "./domain";
 import { staticProjectFile } from "./fixtures/staticProject";
 import "./styles.css";
@@ -12,6 +13,7 @@ const nodeTypes = {
 } satisfies NodeTypes;
 
 function App() {
+  const [project, setProject] = useState(staticProjectFile.project);
   const [canvasView, setCanvasView] = useState(staticProjectFile.canvasView);
 
   const handleToggleExpanded = useCallback((artifactId: ArtifactId) => {
@@ -31,13 +33,32 @@ function App() {
     });
   }, []);
 
+  const handleUpdateBrief = useCallback(
+    (artifactId: ArtifactId, patch: BriefArtifactPatch) => {
+      setProject((currentProject) => ({
+        ...currentProject,
+        canvas: {
+          ...currentProject.canvas,
+          artifacts: currentProject.canvas.artifacts.map((artifact) =>
+            artifact.id === artifactId && artifact.type === "brief"
+              ? { ...artifact, ...patch }
+              : artifact,
+          ),
+        },
+      }));
+    },
+    [],
+  );
+
   const staticGraph = useMemo(
     () =>
       mapProjectFileToReactFlow(staticProjectFile, {
+        project,
         canvasView,
         onToggleExpanded: handleToggleExpanded,
+        onUpdateBrief: handleUpdateBrief,
       }),
-    [canvasView, handleToggleExpanded],
+    [canvasView, handleToggleExpanded, handleUpdateBrief, project],
   );
 
   return (

--- a/src/canvas/ArtifactNode.tsx
+++ b/src/canvas/ArtifactNode.tsx
@@ -1,7 +1,10 @@
-import type { MouseEvent } from "react";
+import type { ChangeEvent, MouseEvent } from "react";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { getPromptTargetLabel } from "./mapFacetsToReactFlow";
-import type { ArtifactNode as ArtifactNodeType } from "./types";
+import type {
+  ArtifactNode as ArtifactNodeType,
+  BriefArtifactPatch,
+} from "./types";
 
 function ArtifactNode({ data }: NodeProps<ArtifactNodeType>) {
   const toggleLabel = data.expanded ? "Collapse" : "Expand";
@@ -30,14 +33,86 @@ function ArtifactNode({ data }: NodeProps<ArtifactNodeType>) {
           {toggleLabel}
         </button>
       </header>
+      <ArtifactNodeBody data={data} />
+      <Handle type="source" position={Position.Right} isConnectable={false} />
+    </article>
+  );
+}
+
+function ArtifactNodeBody({ data }: Pick<ArtifactNodeType, "data">) {
+  if (data.artifact.type === "brief" && data.expanded) {
+    return (
+      <EditableBriefFields
+        artifact={data.artifact}
+        onUpdateBrief={data.onUpdateBrief}
+      />
+    );
+  }
+
+  return (
+    <>
       <h2 className="artifact-node__title">{data.artifact.title}</h2>
       {data.expanded ? (
         <ExpandedArtifactFields artifact={data.artifact} />
       ) : (
         <p className="artifact-node__summary">{data.summary}</p>
       )}
-      <Handle type="source" position={Position.Right} isConnectable={false} />
-    </article>
+    </>
+  );
+}
+
+function EditableBriefFields({
+  artifact,
+  onUpdateBrief,
+}: Pick<ArtifactNodeType["data"], "onUpdateBrief"> & {
+  artifact: Extract<ArtifactNodeType["data"]["artifact"], { type: "brief" }>;
+}) {
+  function handleChange<K extends keyof BriefArtifactPatch>(
+    field: K,
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) {
+    onUpdateBrief?.(artifact.id, { [field]: event.target.value });
+  }
+
+  return (
+    <div className="artifact-node__editor">
+      <label className="artifact-node__edit-field">
+        <span>Title</span>
+        <input
+          className="artifact-node__input nodrag nopan"
+          type="text"
+          value={artifact.title}
+          onChange={(event) => handleChange("title", event)}
+        />
+      </label>
+      <label className="artifact-node__edit-field">
+        <span>Brief</span>
+        <textarea
+          className="artifact-node__textarea nodrag nopan"
+          value={artifact.brief}
+          onChange={(event) => handleChange("brief", event)}
+          rows={4}
+        />
+      </label>
+      <label className="artifact-node__edit-field">
+        <span>Audience</span>
+        <textarea
+          className="artifact-node__textarea nodrag nopan"
+          value={artifact.audience}
+          onChange={(event) => handleChange("audience", event)}
+          rows={2}
+        />
+      </label>
+      <label className="artifact-node__edit-field">
+        <span>Constraints</span>
+        <textarea
+          className="artifact-node__textarea nodrag nopan"
+          value={artifact.constraints}
+          onChange={(event) => handleChange("constraints", event)}
+          rows={3}
+        />
+      </label>
+    </div>
   );
 }
 

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -2,11 +2,17 @@ import type {
   ArtifactId,
   FacetsCanvasView,
   FacetsArtifact,
+  FacetsProject,
   FacetsProjectFile,
   FacetsRelationship,
   PromptTarget,
 } from "../domain";
-import type { ArtifactNode, ArtifactNodeData, RelationshipEdge } from "./types";
+import type {
+  ArtifactNode,
+  ArtifactNodeData,
+  BriefArtifactPatch,
+  RelationshipEdge,
+} from "./types";
 
 export type FacetsReactFlowGraph = {
   nodes: ArtifactNode[];
@@ -14,21 +20,29 @@ export type FacetsReactFlowGraph = {
 };
 
 export type MapProjectFileToReactFlowOptions = {
+  project?: FacetsProject;
   canvasView?: FacetsCanvasView;
   onToggleExpanded?: (artifactId: ArtifactId) => void;
+  onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void;
 };
 
 export function mapProjectFileToReactFlow(
   projectFile: FacetsProjectFile,
   options: MapProjectFileToReactFlowOptions = {},
 ): FacetsReactFlowGraph {
+  const project = options.project ?? projectFile.project;
   const canvasView = options.canvasView ?? projectFile.canvasView;
 
   return {
-    nodes: projectFile.project.canvas.artifacts.map((artifact) =>
-      mapArtifactToNode(artifact, canvasView, options.onToggleExpanded),
+    nodes: project.canvas.artifacts.map((artifact) =>
+      mapArtifactToNode(
+        artifact,
+        canvasView,
+        options.onToggleExpanded,
+        options.onUpdateBrief,
+      ),
     ),
-    edges: projectFile.project.canvas.relationships.map(mapRelationshipToEdge),
+    edges: project.canvas.relationships.map(mapRelationshipToEdge),
   };
 }
 
@@ -36,6 +50,7 @@ function mapArtifactToNode(
   artifact: FacetsArtifact,
   canvasView: FacetsCanvasView,
   onToggleExpanded?: (artifactId: ArtifactId) => void,
+  onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void,
 ): ArtifactNode {
   const nodeView = canvasView.nodes[artifact.id];
 
@@ -47,6 +62,7 @@ function mapArtifactToNode(
       artifact,
       Boolean(nodeView.expanded),
       onToggleExpanded,
+      onUpdateBrief,
     ),
     draggable: false,
     selectable: false,
@@ -64,6 +80,7 @@ function getArtifactNodeData(
   artifact: FacetsArtifact,
   expanded: boolean,
   onToggleExpanded?: (artifactId: ArtifactId) => void,
+  onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void,
 ): ArtifactNodeData {
   switch (artifact.type) {
     case "brief":
@@ -73,6 +90,7 @@ function getArtifactNodeData(
         summary: artifact.brief,
         expanded,
         onToggleExpanded,
+        onUpdateBrief,
       };
     case "direction":
       return {

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -1,5 +1,14 @@
 import type { Edge, Node } from "@xyflow/react";
-import type { ArtifactId, FacetsArtifact, FacetsRelationship } from "../domain";
+import type {
+  ArtifactId,
+  BriefArtifact,
+  FacetsArtifact,
+  FacetsRelationship,
+} from "../domain";
+
+export type BriefArtifactPatch = Partial<
+  Pick<BriefArtifact, "title" | "brief" | "audience" | "constraints">
+>;
 
 export type ArtifactNodeData = {
   artifact: FacetsArtifact;
@@ -7,6 +16,7 @@ export type ArtifactNodeData = {
   summary: string;
   expanded: boolean;
   onToggleExpanded?: (artifactId: ArtifactId) => void;
+  onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void;
 };
 
 export type ArtifactNode = Node<ArtifactNodeData, "artifact">;

--- a/src/styles.css
+++ b/src/styles.css
@@ -66,7 +66,9 @@ body {
 }
 
 .artifact-node,
-.artifact-node__action {
+.artifact-node__action,
+.artifact-node__input,
+.artifact-node__textarea {
   pointer-events: auto;
 }
 
@@ -147,12 +149,18 @@ body {
   margin: 18px 0 0;
 }
 
+.artifact-node__editor {
+  display: grid;
+  gap: 14px;
+}
+
 .artifact-node__field {
   display: grid;
   gap: 5px;
 }
 
-.artifact-node__field dt {
+.artifact-node__field dt,
+.artifact-node__edit-field span {
   color: #81786a;
   font-size: 11px;
   font-weight: 800;
@@ -160,11 +168,50 @@ body {
   text-transform: uppercase;
 }
 
+.artifact-node__edit-field {
+  display: grid;
+  gap: 6px;
+}
+
 .artifact-node__field dd {
   margin: 0;
   color: #4f4a42;
   font-size: 13px;
   line-height: 1.42;
+}
+
+.artifact-node__input,
+.artifact-node__textarea {
+  width: 100%;
+  color: #24251f;
+  font: inherit;
+  letter-spacing: 0;
+  background: #fffdf7;
+  border: 1px solid rgba(31, 35, 32, 0.18);
+  border-radius: 7px;
+  outline: none;
+}
+
+.artifact-node__input {
+  min-height: 38px;
+  padding: 8px 10px;
+  font-size: 18px;
+  font-weight: 750;
+  line-height: 1.15;
+}
+
+.artifact-node__textarea {
+  min-height: 64px;
+  padding: 9px 10px;
+  font-size: 13px;
+  line-height: 1.42;
+  resize: vertical;
+}
+
+.artifact-node__input:focus,
+.artifact-node__textarea:focus {
+  border-color: rgba(31, 124, 96, 0.5);
+  box-shadow: 0 0 0 3px rgba(31, 124, 96, 0.13);
 }
 
 .artifact-node__action {


### PR DESCRIPTION
## Summary
- Adds in-memory FacetsProject state in App.tsx initialized from the static project fixture.
- Makes expanded Brief nodes editable for title, brief, audience, and constraints.
- Keeps Direction and Prompt nodes readonly and keeps the React Flow mapper as a render adapter.

## Issue
Addresses #16.

## Acceptance Criteria
- [x] Expanded Brief nodes expose editable title, brief, audience, and constraints fields directly on the canvas.
- [x] Brief edits update the in-memory Facets artifact model.
- [x] Collapsed Brief title and summary reflect edited model values after collapsing.
- [x] Direction and Prompt expanded states remain readonly.
- [x] No persistence, save/load, prompt copy/export, inspector, side panel, modal, fullscreen editor, model/API calls, or Figma MCP behavior is introduced.
- [x] src/domain remains free of React and @xyflow/react dependencies.

## Validation
- [x] npm run build
- [x] git diff --check
- [x] Dev server loaded at http://127.0.0.1:1420/.
- [x] Browser verified Brief expand, edit title/brief/audience/constraints, collapse, and updated collapsed title/summary.
- [x] Browser verified Direction and Prompt expanded nodes contain no form inputs.
- [x] Browser console had no errors.
- [x] Confirmed src/domain has no React or @xyflow/react imports.

## Notes
This stays in-memory only. Persistence remains deferred to issue #6, and Direction/Prompt editing remains deferred to issue #17.