### PR TITLE
Add Brief-to-Direction generation action

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import ArtifactNode from "./canvas/ArtifactNode";
+import DirectionGroupNode from "./canvas/DirectionGroupNode";
 import { mapProjectFileToReactFlow } from "./canvas/mapFacetsToReactFlow";
 import RelationshipEdge from "./canvas/RelationshipEdge";
 import type { BriefArtifactPatch } from "./canvas/types";
@@ -21,8 +22,8 @@ import { staticProjectFile } from "./fixtures/staticProject";
 import "./styles.css";
 
 const GENERATED_DIRECTIONS_PER_CLICK = 3;
-const GENERATED_DIRECTION_X = 440;
-const GENERATED_DIRECTION_START_Y = 300;
+const GENERATED_DIRECTION_X = 20;
+const GENERATED_DIRECTION_START_Y = 64;
 const GENERATED_DIRECTION_Y_GAP = 260;
 const GENERATED_DIRECTION_WIDTH = 340;
 const GENERATED_DIRECTION_HEIGHT = 220;
@@ -30,6 +31,7 @@ const generatedDirectionIdPattern = /^direction-generated-(\d+)$/;
 
 const nodeTypes = {
   artifact: ArtifactNode,
+  directionGroup: DirectionGroupNode,
 } satisfies NodeTypes;
 
 const edgeTypes = {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,40 @@
 import { useCallback, useMemo, useState } from "react";
-import { Background, Controls, ReactFlow, type NodeTypes } from "@xyflow/react";
+import {
+  Background,
+  Controls,
+  ReactFlow,
+  type EdgeTypes,
+  type NodeTypes,
+} from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import ArtifactNode from "./canvas/ArtifactNode";
 import { mapProjectFileToReactFlow } from "./canvas/mapFacetsToReactFlow";
+import RelationshipEdge from "./canvas/RelationshipEdge";
 import type { BriefArtifactPatch } from "./canvas/types";
-import type { ArtifactId } from "./domain";
+import type {
+  ArtifactId,
+  BriefArtifact,
+  DirectionArtifact,
+  FacetsRelationship,
+} from "./domain";
 import { staticProjectFile } from "./fixtures/staticProject";
 import "./styles.css";
+
+const GENERATED_DIRECTIONS_PER_CLICK = 3;
+const GENERATED_DIRECTION_X = 440;
+const GENERATED_DIRECTION_START_Y = 300;
+const GENERATED_DIRECTION_Y_GAP = 260;
+const GENERATED_DIRECTION_WIDTH = 340;
+const GENERATED_DIRECTION_HEIGHT = 220;
+const generatedDirectionIdPattern = /^direction-generated-(\d+)$/;
 
 const nodeTypes = {
   artifact: ArtifactNode,
 } satisfies NodeTypes;
+
+const edgeTypes = {
+  relationship: RelationshipEdge,
+} satisfies EdgeTypes;
 
 function App() {
   const [project, setProject] = useState(staticProjectFile.project);
@@ -50,6 +74,89 @@ function App() {
     [],
   );
 
+  const handleGenerateDirections = useCallback(
+    (sourceBriefId: ArtifactId) => {
+      const brief = project.canvas.artifacts.find(
+        (artifact): artifact is BriefArtifact =>
+          artifact.id === sourceBriefId && artifact.type === "brief",
+      );
+
+      if (!brief) {
+        return;
+      }
+
+      const existingGeneratedCount = project.canvas.artifacts.filter(
+        (artifact) =>
+          artifact.type === "direction" &&
+          generatedDirectionIdPattern.test(artifact.id),
+      ).length;
+      const generatedDirections: DirectionArtifact[] = Array.from(
+        { length: GENERATED_DIRECTIONS_PER_CLICK },
+        (_, index) => {
+          const directionNumber = existingGeneratedCount + index + 1;
+
+          return {
+            id: `direction-generated-${directionNumber}`,
+            type: "direction",
+            title: `Generated direction ${directionNumber}`,
+            angle: `A local concept angle for "${brief.title}".`,
+            notes: `Placeholder direction generated from the current brief: ${brief.brief}`,
+            rationale:
+              "This deterministic placeholder proves the Brief-to-Direction workflow before model generation exists.",
+          };
+        },
+      );
+      const generatedRelationships: FacetsRelationship[] =
+        generatedDirections.map((direction) => ({
+          id: `relationship-${sourceBriefId}-${direction.id}`,
+          type: "brief_to_direction",
+          sourceId: sourceBriefId,
+          targetId: direction.id,
+        }));
+
+      setProject({
+        ...project,
+        canvas: {
+          ...project.canvas,
+          artifacts: [...project.canvas.artifacts, ...generatedDirections],
+          relationships: [
+            ...project.canvas.relationships,
+            ...generatedRelationships,
+          ],
+        },
+      });
+      setCanvasView({
+        ...canvasView,
+        nodes: {
+          ...canvasView.nodes,
+          ...Object.fromEntries(
+            generatedDirections.map((direction, index) => {
+              const generatedIndex = existingGeneratedCount + index;
+
+              return [
+                direction.id,
+                {
+                  expanded: false,
+                  position: {
+                    x: GENERATED_DIRECTION_X,
+                    y:
+                      GENERATED_DIRECTION_START_Y +
+                      generatedIndex * GENERATED_DIRECTION_Y_GAP,
+                  },
+                  size: {
+                    width: GENERATED_DIRECTION_WIDTH,
+                    height: GENERATED_DIRECTION_HEIGHT,
+                  },
+                },
+              ];
+            }),
+          ),
+        },
+      });
+    },
+    [canvasView, project],
+  );
+
   const staticGraph = useMemo(
     () =>
       mapProjectFileToReactFlow(staticProjectFile, {
@@ -57,8 +164,15 @@ function App() {
         canvasView,
         onToggleExpanded: handleToggleExpanded,
         onUpdateBrief: handleUpdateBrief,
+        onGenerateDirections: handleGenerateDirections,
       }),
-    [canvasView, handleToggleExpanded, handleUpdateBrief, project],
+    [
+      canvasView,
+      handleGenerateDirections,
+      handleToggleExpanded,
+      handleUpdateBrief,
+      project,
+    ],
   );
 
   return (
@@ -67,6 +181,7 @@ function App() {
         nodes={staticGraph.nodes}
         edges={staticGraph.edges}
         nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
         fitView
         nodesDraggable={false}
         nodesConnectable={false}

--- a/src/canvas/DirectionGroupNode.tsx
+++ b/src/canvas/DirectionGroupNode.tsx
@@ -1,9 +1,10 @@
-import type { NodeProps } from "@xyflow/react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
 import type { DirectionGroupNode as DirectionGroupNodeType } from "./types";
 
 function DirectionGroupNode({ data }: NodeProps<DirectionGroupNodeType>) {
   return (
     <section className="direction-group-node">
+      <Handle type="target" position={Position.Left} isConnectable={false} />
       <header className="direction-group-node__header">
         <span>{data.title}</span>
         <span>{data.count}</span>

--- a/src/canvas/DirectionGroupNode.tsx
+++ b/src/canvas/DirectionGroupNode.tsx
@@ -1,0 +1,15 @@
+import type { NodeProps } from "@xyflow/react";
+import type { DirectionGroupNode as DirectionGroupNodeType } from "./types";
+
+function DirectionGroupNode({ data }: NodeProps<DirectionGroupNodeType>) {
+  return (
+    <section className="direction-group-node">
+      <header className="direction-group-node__header">
+        <span>{data.title}</span>
+        <span>{data.count}</span>
+      </header>
+    </section>
+  );
+}
+
+export default DirectionGroupNode;

--- a/src/canvas/RelationshipEdge.tsx
+++ b/src/canvas/RelationshipEdge.tsx
@@ -1,0 +1,67 @@
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getSmoothStepPath,
+  type EdgeProps,
+} from "@xyflow/react";
+import type { MouseEvent } from "react";
+import type { RelationshipEdge as RelationshipEdgeType } from "./types";
+
+function RelationshipEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  label,
+  data,
+}: EdgeProps<RelationshipEdgeType>) {
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  function handleGenerateClick(event: MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+
+    if (data?.relationship.type === "brief_to_direction") {
+      data.onGenerateDirections?.(data.relationship.sourceId);
+    }
+  }
+
+  return (
+    <>
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        label={data?.showGenerateDirections ? undefined : label}
+      />
+      {data?.showGenerateDirections ? (
+        <EdgeLabelRenderer>
+          <div
+            className="relationship-edge__label nodrag nopan"
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+          >
+            <button
+              className="relationship-edge__button"
+              type="button"
+              onClick={handleGenerateClick}
+            >
+              Generate directions
+            </button>
+          </div>
+        </EdgeLabelRenderer>
+      ) : null}
+    </>
+  );
+}
+
+export default RelationshipEdge;

--- a/src/canvas/RelationshipEdge.tsx
+++ b/src/canvas/RelationshipEdge.tsx
@@ -30,8 +30,8 @@ function RelationshipEdge({
   function handleGenerateClick(event: MouseEvent<HTMLButtonElement>) {
     event.stopPropagation();
 
-    if (data?.relationship.type === "brief_to_direction") {
-      data.onGenerateDirections?.(data.relationship.sourceId);
+    if (data?.sourceBriefId) {
+      data.onGenerateDirections?.(data.sourceBriefId);
     }
   }
 

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -11,11 +11,21 @@ import type {
   ArtifactNode,
   ArtifactNodeData,
   BriefArtifactPatch,
+  DirectionGroupNode,
+  FacetsCanvasNode,
   RelationshipEdge,
 } from "./types";
 
+const GENERATED_DIRECTIONS_GROUP_ID = "generated-directions-group";
+const GENERATED_DIRECTION_GROUP_X = 420;
+const GENERATED_DIRECTION_GROUP_Y = 260;
+const GENERATED_DIRECTION_GROUP_WIDTH = 380;
+const GENERATED_DIRECTION_GROUP_ROW_HEIGHT = 260;
+const GENERATED_DIRECTION_GROUP_BASE_HEIGHT = 48;
+const generatedDirectionIdPattern = /^direction-generated-\d+$/;
+
 export type FacetsReactFlowGraph = {
-  nodes: ArtifactNode[];
+  nodes: FacetsCanvasNode[];
   edges: RelationshipEdge[];
 };
 
@@ -42,15 +52,26 @@ export function mapProjectFileToReactFlow(
       artifactsById.get(relationship.sourceId)?.type === "brief",
   )?.id;
 
+  const generatedDirectionCount = project.canvas.artifacts.filter(
+    isGeneratedDirectionArtifact,
+  ).length;
+  const generatedDirectionsGroupNode =
+    generatedDirectionCount > 0
+      ? [mapGeneratedDirectionsGroupNode(generatedDirectionCount)]
+      : [];
+
   return {
-    nodes: project.canvas.artifacts.map((artifact) =>
-      mapArtifactToNode(
-        artifact,
-        canvasView,
-        options.onToggleExpanded,
-        options.onUpdateBrief,
+    nodes: [
+      ...generatedDirectionsGroupNode,
+      ...project.canvas.artifacts.map((artifact) =>
+        mapArtifactToNode(
+          artifact,
+          canvasView,
+          options.onToggleExpanded,
+          options.onUpdateBrief,
+        ),
       ),
-    ),
+    ],
     edges: project.canvas.relationships.map((relationship) =>
       mapRelationshipToEdge(
         relationship,
@@ -68,11 +89,14 @@ function mapArtifactToNode(
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void,
 ): ArtifactNode {
   const nodeView = canvasView.nodes[artifact.id];
+  const isGeneratedDirection = isGeneratedDirectionArtifact(artifact);
 
   return {
     id: artifact.id,
     type: "artifact",
     position: nodeView.position,
+    parentId: isGeneratedDirection ? GENERATED_DIRECTIONS_GROUP_ID : undefined,
+    extent: isGeneratedDirection ? "parent" : undefined,
     data: getArtifactNodeData(
       artifact,
       Boolean(nodeView.expanded),
@@ -89,6 +113,39 @@ function mapArtifactToNode(
         }
       : undefined,
   };
+}
+
+function mapGeneratedDirectionsGroupNode(
+  generatedDirectionCount: number,
+): DirectionGroupNode {
+  return {
+    id: GENERATED_DIRECTIONS_GROUP_ID,
+    type: "directionGroup",
+    position: {
+      x: GENERATED_DIRECTION_GROUP_X,
+      y: GENERATED_DIRECTION_GROUP_Y,
+    },
+    data: {
+      title: "Generated directions",
+      count: generatedDirectionCount,
+    },
+    draggable: false,
+    selectable: false,
+    zIndex: 1,
+    style: {
+      width: GENERATED_DIRECTION_GROUP_WIDTH,
+      height:
+        GENERATED_DIRECTION_GROUP_BASE_HEIGHT +
+        generatedDirectionCount * GENERATED_DIRECTION_GROUP_ROW_HEIGHT,
+    },
+  };
+}
+
+function isGeneratedDirectionArtifact(artifact: FacetsArtifact): boolean {
+  return (
+    artifact.type === "direction" &&
+    generatedDirectionIdPattern.test(artifact.id)
+  );
 }
 
 function getArtifactNodeData(

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -55,6 +55,20 @@ export function mapProjectFileToReactFlow(
   const generatedDirectionCount = project.canvas.artifacts.filter(
     isGeneratedDirectionArtifact,
   ).length;
+  const generatedDirectionRelationships = project.canvas.relationships.filter(
+    (relationship) =>
+      relationship.type === "brief_to_direction" &&
+      isGeneratedDirectionArtifact(artifactsById.get(relationship.targetId)),
+  );
+  const generatedDirectionGroupEdge =
+    generatedDirectionCount > 0 && generatedDirectionRelationships.length > 0
+      ? [
+          mapGeneratedDirectionsGroupEdge(
+            generatedDirectionRelationships[0],
+            options.onGenerateDirections,
+          ),
+        ]
+      : [];
   const generatedDirectionsGroupNode =
     generatedDirectionCount > 0
       ? [mapGeneratedDirectionsGroupNode(generatedDirectionCount)]
@@ -72,13 +86,24 @@ export function mapProjectFileToReactFlow(
         ),
       ),
     ],
-    edges: project.canvas.relationships.map((relationship) =>
-      mapRelationshipToEdge(
-        relationship,
-        relationship.id === generateDirectionsRelationshipId,
-        options.onGenerateDirections,
+    edges: [
+      ...project.canvas.relationships
+        .filter(
+          (relationship) =>
+            !isGeneratedDirectionArtifact(
+              artifactsById.get(relationship.targetId),
+            ),
+        )
+        .map((relationship) =>
+          mapRelationshipToEdge(
+            relationship,
+            generatedDirectionCount === 0 &&
+              relationship.id === generateDirectionsRelationshipId,
+            options.onGenerateDirections,
+          ),
       ),
-    ),
+      ...generatedDirectionGroupEdge,
+    ],
   };
 }
 
@@ -141,9 +166,31 @@ function mapGeneratedDirectionsGroupNode(
   };
 }
 
-function isGeneratedDirectionArtifact(artifact: FacetsArtifact): boolean {
+function mapGeneratedDirectionsGroupEdge(
+  relationship: FacetsRelationship,
+  onGenerateDirections?: (sourceBriefId: ArtifactId) => void,
+): RelationshipEdge {
+  return {
+    id: `relationship-${relationship.sourceId}-${GENERATED_DIRECTIONS_GROUP_ID}`,
+    type: "relationship",
+    source: relationship.sourceId,
+    target: GENERATED_DIRECTIONS_GROUP_ID,
+    label: "Generated directions",
+    data: {
+      relationship,
+      showGenerateDirections: true,
+      onGenerateDirections,
+    },
+    selectable: false,
+    reconnectable: false,
+  };
+}
+
+function isGeneratedDirectionArtifact(
+  artifact: FacetsArtifact | undefined,
+): boolean {
   return (
-    artifact.type === "direction" &&
+    artifact?.type === "direction" &&
     generatedDirectionIdPattern.test(artifact.id)
   );
 }

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -24,6 +24,7 @@ export type MapProjectFileToReactFlowOptions = {
   canvasView?: FacetsCanvasView;
   onToggleExpanded?: (artifactId: ArtifactId) => void;
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void;
+  onGenerateDirections?: (sourceBriefId: ArtifactId) => void;
 };
 
 export function mapProjectFileToReactFlow(
@@ -32,6 +33,14 @@ export function mapProjectFileToReactFlow(
 ): FacetsReactFlowGraph {
   const project = options.project ?? projectFile.project;
   const canvasView = options.canvasView ?? projectFile.canvasView;
+  const artifactsById = new Map(
+    project.canvas.artifacts.map((artifact) => [artifact.id, artifact]),
+  );
+  const generateDirectionsRelationshipId = project.canvas.relationships.find(
+    (relationship) =>
+      relationship.type === "brief_to_direction" &&
+      artifactsById.get(relationship.sourceId)?.type === "brief",
+  )?.id;
 
   return {
     nodes: project.canvas.artifacts.map((artifact) =>
@@ -42,7 +51,13 @@ export function mapProjectFileToReactFlow(
         options.onUpdateBrief,
       ),
     ),
-    edges: project.canvas.relationships.map(mapRelationshipToEdge),
+    edges: project.canvas.relationships.map((relationship) =>
+      mapRelationshipToEdge(
+        relationship,
+        relationship.id === generateDirectionsRelationshipId,
+        options.onGenerateDirections,
+      ),
+    ),
   };
 }
 
@@ -113,14 +128,20 @@ function getArtifactNodeData(
 
 function mapRelationshipToEdge(
   relationship: FacetsRelationship,
+  showGenerateDirections: boolean,
+  onGenerateDirections?: (sourceBriefId: ArtifactId) => void,
 ): RelationshipEdge {
   return {
     id: relationship.id,
-    type: "smoothstep",
+    type: "relationship",
     source: relationship.sourceId,
     target: relationship.targetId,
     label: getRelationshipLabel(relationship),
-    data: { relationship },
+    data: {
+      relationship,
+      showGenerateDirections,
+      onGenerateDirections,
+    },
     selectable: false,
     reconnectable: false,
   };

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -18,7 +18,7 @@ import type {
 
 const GENERATED_DIRECTIONS_GROUP_ID = "generated-directions-group";
 const GENERATED_DIRECTION_GROUP_X = 420;
-const GENERATED_DIRECTION_GROUP_Y = 260;
+const GENERATED_DIRECTION_GROUP_Y = 0;
 const GENERATED_DIRECTION_GROUP_WIDTH = 380;
 const GENERATED_DIRECTION_GROUP_ROW_HEIGHT = 260;
 const GENERATED_DIRECTION_GROUP_BASE_HEIGHT = 48;
@@ -51,6 +51,9 @@ export function mapProjectFileToReactFlow(
       relationship.type === "brief_to_direction" &&
       artifactsById.get(relationship.sourceId)?.type === "brief",
   )?.id;
+  const sourceBrief = project.canvas.artifacts.find(
+    (artifact) => artifact.type === "brief",
+  );
 
   const generatedDirectionCount = project.canvas.artifacts.filter(
     isGeneratedDirectionArtifact,
@@ -68,15 +71,18 @@ export function mapProjectFileToReactFlow(
             options.onGenerateDirections,
           ),
         ]
-      : [];
-  const generatedDirectionsGroupNode =
-    generatedDirectionCount > 0
-      ? [mapGeneratedDirectionsGroupNode(generatedDirectionCount)]
-      : [];
+      : sourceBrief
+        ? [
+            mapEmptyGeneratedDirectionsGroupEdge(
+              sourceBrief.id,
+              options.onGenerateDirections,
+            ),
+          ]
+        : [];
 
   return {
     nodes: [
-      ...generatedDirectionsGroupNode,
+      mapGeneratedDirectionsGroupNode(generatedDirectionCount),
       ...project.canvas.artifacts.map((artifact) =>
         mapArtifactToNode(
           artifact,
@@ -97,7 +103,7 @@ export function mapProjectFileToReactFlow(
         .map((relationship) =>
           mapRelationshipToEdge(
             relationship,
-            generatedDirectionCount === 0 &&
+            generatedDirectionCount === 0 && !sourceBrief &&
               relationship.id === generateDirectionsRelationshipId,
             options.onGenerateDirections,
           ),
@@ -161,7 +167,8 @@ function mapGeneratedDirectionsGroupNode(
       width: GENERATED_DIRECTION_GROUP_WIDTH,
       height:
         GENERATED_DIRECTION_GROUP_BASE_HEIGHT +
-        generatedDirectionCount * GENERATED_DIRECTION_GROUP_ROW_HEIGHT,
+        Math.max(generatedDirectionCount, 1) *
+          GENERATED_DIRECTION_GROUP_ROW_HEIGHT,
     },
   };
 }
@@ -178,6 +185,27 @@ function mapGeneratedDirectionsGroupEdge(
     label: "Generated directions",
     data: {
       relationship,
+      sourceBriefId: relationship.sourceId,
+      showGenerateDirections: true,
+      onGenerateDirections,
+    },
+    selectable: false,
+    reconnectable: false,
+  };
+}
+
+function mapEmptyGeneratedDirectionsGroupEdge(
+  sourceBriefId: ArtifactId,
+  onGenerateDirections?: (sourceBriefId: ArtifactId) => void,
+): RelationshipEdge {
+  return {
+    id: `relationship-${sourceBriefId}-${GENERATED_DIRECTIONS_GROUP_ID}`,
+    type: "relationship",
+    source: sourceBriefId,
+    target: GENERATED_DIRECTIONS_GROUP_ID,
+    label: "Generated directions",
+    data: {
+      sourceBriefId,
       showGenerateDirections: true,
       onGenerateDirections,
     },

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -34,7 +34,8 @@ export type DirectionGroupNode = Node<
 export type FacetsCanvasNode = ArtifactNode | DirectionGroupNode;
 
 export type RelationshipEdgeData = {
-  relationship: FacetsRelationship;
+  relationship?: FacetsRelationship;
+  sourceBriefId?: ArtifactId;
   showGenerateDirections?: boolean;
   onGenerateDirections?: (sourceBriefId: ArtifactId) => void;
 };

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -21,6 +21,18 @@ export type ArtifactNodeData = {
 
 export type ArtifactNode = Node<ArtifactNodeData, "artifact">;
 
+export type DirectionGroupNodeData = {
+  title: string;
+  count: number;
+};
+
+export type DirectionGroupNode = Node<
+  DirectionGroupNodeData,
+  "directionGroup"
+>;
+
+export type FacetsCanvasNode = ArtifactNode | DirectionGroupNode;
+
 export type RelationshipEdgeData = {
   relationship: FacetsRelationship;
   showGenerateDirections?: boolean;

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -23,6 +23,8 @@ export type ArtifactNode = Node<ArtifactNodeData, "artifact">;
 
 export type RelationshipEdgeData = {
   relationship: FacetsRelationship;
+  showGenerateDirections?: boolean;
+  onGenerateDirections?: (sourceBriefId: ArtifactId) => void;
 };
 
-export type RelationshipEdge = Edge<RelationshipEdgeData, "smoothstep">;
+export type RelationshipEdge = Edge<RelationshipEdgeData, "relationship">;

--- a/src/fixtures/staticProject.ts
+++ b/src/fixtures/staticProject.ts
@@ -19,42 +19,8 @@ export const staticProjectFile: FacetsProjectFile = {
           constraints:
             "Keep it practical, canvas-first, and focused on better prompts for design agents.",
         },
-        {
-          id: "direction-static-workbench",
-          type: "direction",
-          title: "Workbench canvas",
-          angle:
-            "Show the design process as connected editable artifacts instead of a form-heavy workflow.",
-          notes:
-            "Lead with a simple canvas that makes the path from brief to direction to prompt visible.",
-          rationale:
-            "The structure helps designers guide agent work without turning Facets into an execution tool.",
-        },
-        {
-          id: "prompt-static-first-concept",
-          type: "prompt",
-          title: "Generate first concept",
-          target: "chatgpt",
-          summary:
-            "Ask an external agent to create a first Figma concept from the selected direction.",
-          promptText:
-            "Create a homepage concept in Figma based on the brief and workbench canvas direction.",
-        },
       ],
-      relationships: [
-        {
-          id: "relationship-static-brief-direction",
-          type: "brief_to_direction",
-          sourceId: "brief-static-homepage",
-          targetId: "direction-static-workbench",
-        },
-        {
-          id: "relationship-static-direction-prompt",
-          type: "direction_to_prompt",
-          sourceId: "direction-static-workbench",
-          targetId: "prompt-static-first-concept",
-        },
-      ],
+      relationships: [],
     },
   },
   canvasView: {
@@ -69,16 +35,6 @@ export const staticProjectFile: FacetsProjectFile = {
         expanded: false,
         position: { x: 0, y: 0 },
         size: { width: 320, height: 220 },
-      },
-      "direction-static-workbench": {
-        expanded: false,
-        position: { x: 440, y: 0 },
-        size: { width: 340, height: 220 },
-      },
-      "prompt-static-first-concept": {
-        expanded: false,
-        position: { x: 900, y: 0 },
-        size: { width: 340, height: 220 },
       },
     },
   },

--- a/src/styles.css
+++ b/src/styles.css
@@ -60,6 +60,36 @@ body {
   letter-spacing: 0;
 }
 
+.relationship-edge__label {
+  position: absolute;
+  pointer-events: all;
+}
+
+.relationship-edge__button {
+  min-height: 30px;
+  padding: 0 12px;
+  color: #fffdf7;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0;
+  white-space: nowrap;
+  background: #1f7c60;
+  border: 1px solid rgba(31, 35, 32, 0.1);
+  border-radius: 7px;
+  box-shadow: 0 10px 24px rgba(54, 48, 36, 0.16);
+  cursor: pointer;
+}
+
+.relationship-edge__button:hover {
+  background: #18684f;
+}
+
+.relationship-edge__button:focus-visible {
+  outline: 3px solid rgba(31, 124, 96, 0.24);
+  outline-offset: 2px;
+}
+
 .react-flow__node {
   z-index: 2;
   pointer-events: all !important;

--- a/src/styles.css
+++ b/src/styles.css
@@ -95,6 +95,32 @@ body {
   pointer-events: all !important;
 }
 
+.react-flow__node-directionGroup {
+  pointer-events: none !important;
+}
+
+.direction-group-node {
+  width: 100%;
+  height: 100%;
+  padding: 14px;
+  background: rgba(255, 253, 247, 0.48);
+  border: 1px dashed rgba(88, 99, 131, 0.32);
+  border-radius: 10px;
+}
+
+.direction-group-node__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 28px;
+  padding: 0 4px;
+  color: #586383;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
 .artifact-node,
 .artifact-node__action,
 .artifact-node__input,


### PR DESCRIPTION
## Summary
- Adds a custom React Flow relationship edge with a between-nodes Generate directions CTA.
- Starts the static canvas as Brief → empty Generated directions group, with no placeholder Direction or Prompt fixture nodes.
- Adds local deterministic Brief-to-Direction generation that appends three Direction artifacts and relationships in memory.
- Groups generated Direction nodes inside a view-only Generated directions parent node.
- Renders generated Brief-to-Direction relationships as one Brief → Generated directions group edge, rather than one edge per generated card.
- Places repeated generated sets deterministically inside that parent without overlap.

## Issue
Addresses #20.

## Acceptance Criteria
- [x] Initial canvas starts with a Brief and empty Generated directions group.
- [x] Users can progress from an edited Brief to generated Direction artifacts without leaving the canvas.
- [x] Generation action is visibly associated with the Brief-to-Direction transition as an edge CTA.
- [x] Generated Direction artifacts are added to `project.canvas.artifacts` in memory.
- [x] New `brief_to_direction` relationships are added to `project.canvas.relationships` in memory.
- [x] React Flow edges render generated relationships as a group-level view, not manually maintained edge state.
- [x] Generated Directions render inside a view-only Generated directions parent node.
- [x] Generated relationships render as a single Brief-to-group edge, not individual Brief-to-card edges.
- [x] Placeholder Direction content is deterministic and local.
- [x] Generated Directions use deterministic IDs and titles.
- [x] Repeated clicks place each new set below the previous generated set without overlap.
- [x] No OpenAI/API/model execution is introduced.
- [x] No persistence, save/load, prompt copy/export, inspector, side panel, modal, fullscreen editor, or Figma MCP behavior is introduced.
- [x] src/domain remains free of React and @xyflow/react dependencies.

## Validation
- [x] npm run build
- [x] git diff --check
- [x] Dev server loaded at http://127.0.0.1:1420/.
- [x] Browser verified initial canvas has only Brief, empty Generated directions group, and one Brief-to-group CTA edge.
- [x] Browser verified first click adds direction-generated-1 through direction-generated-3 inside the group.
- [x] Browser verified generated group count updates from 0 to 3.
- [x] Browser verified generated relationships render as a single Brief-to-group edge and no per-generated-card edges.
- [x] Browser verified one Generate directions edge CTA remains in the DOM.
- [x] Browser console had no errors.
- [x] Confirmed src/domain has no React or @xyflow/react imports.

## Notes
The generated parent node and empty-state edge are React Flow view constructs, not Facets artifacts. This remains local and deterministic. Real provider-backed generation is deferred to a later issue.