### PR TITLE
Define Direction Set interaction model

### DIFF
--- a/docs/artifact-model.md
+++ b/docs/artifact-model.md
@@ -22,6 +22,25 @@ type FacetsCanvas = {
 
 The canvas groups artifact and relationship content. Local project files store canvas rendering state separately.
 
+## Direction Sets
+
+A Direction Set is a Facets domain grouping concept for organizing Direction artifacts generated from or associated with a Brief.
+
+Direction Sets are not artifacts. They do not expand the core artifact union beyond Brief, Direction, and Prompt. Direction artifacts remain the concept-level design options; Direction Sets organize those options.
+
+The minimal v1 Direction Set shape is intentionally small:
+
+```ts
+type DirectionSet = {
+  id: DirectionSetId;
+  title: string;
+};
+```
+
+The first implementation should treat `title` as the only Direction Set content field. Summaries, generation provenance, brief snapshots, timestamps, selection state, and model/provider metadata remain deferred.
+
+Direction Sets are project data, not React Flow state. React Flow group nodes may render Direction Sets on the canvas, but the React Flow group node is not the source of truth for the Direction Set.
+
 ## Artifacts
 
 Facets has three artifact types:
@@ -61,6 +80,13 @@ Relationship types are:
 - `direction_to_prompt`
 - `prompt_sequence`
 
+Direction Set implementation work should add relationship types for grouping without turning React Flow edges into model state:
+
+- `brief_to_direction_set`
+- `contains_direction`
+
+`brief_to_direction_set` connects a Brief to a Direction Set. `contains_direction` connects a Direction Set to each Direction artifact in that set.
+
 React Flow edges should be derived from these relationship objects.
 
 ## React Flow Boundary
@@ -70,6 +96,8 @@ Facets artifacts and relationships are the source of truth. React Flow nodes and
 React Flow `node.data` can carry whatever a canvas component needs to render, but it must not become the long-term artifact store for Brief, Direction, Prompt, or relationship content.
 
 Collapsed and expanded node state is canvas rendering state, not artifact content. Local project files keep this state outside `FacetsProject.canvas` so artifact content remains separate from view state.
+
+The same boundary applies to Direction Sets. A React Flow group node can render a Direction Set, but Direction Set identity, title, and membership should come from Facets project data and relationships.
 
 ## Persistence Boundary
 

--- a/docs/product-direction.md
+++ b/docs/product-direction.md
@@ -16,6 +16,37 @@ React Flow renders those artifacts, but React Flow node data is not the long-ter
 
 See [Artifact model](artifact-model.md) for the initial TypeScript domain model and React Flow boundary.
 
+## Direction Sets
+
+A Direction Set is the v1 product model for organizing concept directions generated from a Brief.
+
+Direction Sets are not a fourth artifact type. Brief, Direction, and Prompt remain the core editable artifacts. A Direction Set is a domain grouping concept that can be saved as project data later and rendered as a group on the React Flow canvas.
+
+The initial Direction Set field is:
+
+- title
+
+The default naming pattern can be simple and deterministic, such as `Direction Set 1`, `Direction Set 2`, and so on. Richer naming, summaries, timestamps, brief snapshots, and generation provenance are deferred.
+
+## Direction Set Workflow
+
+A new canvas can start with a Brief and an empty Direction Set. The empty set is the visible destination for Direction work before any Directions exist.
+
+Brief nodes own starting a fresh exploration:
+
+- `Create direction set` creates a new empty Direction Set connected to the current Brief.
+
+Direction Set headers own generating Direction options:
+
+- `Generate directions` on an empty set creates the first batch of Direction nodes in that set.
+- `Generate more` or equivalent copy on a populated set appends another batch to that same set.
+
+When the Brief changes, generating again in the current set should append to that set by default. Creating a new Direction Set is the explicit way to preserve prior exploration and start a fresh run from the modified Brief.
+
+Multiple Direction Sets can be connected to the same Brief. They represent different explorations, runs, or facets of the same design problem.
+
+Drag-to-create and drag-to-connect gestures are deferred. V1 should use explicit controls before adding advanced canvas gestures.
+
 ## Core Relationships
 
 Facets owns relationship types separately from React Flow edges:
@@ -25,6 +56,13 @@ Facets owns relationship types separately from React Flow edges:
 - `prompt_sequence`
 
 React Flow edges are view objects derived from Facets relationships.
+
+Direction Sets introduce model relationships that should be represented in Facets project data before they are rendered as React Flow edges:
+
+- `brief_to_direction_set`
+- `contains_direction`
+
+These relationship names are the intended model direction for the Direction Set implementation work. Existing relationship types remain valid for the current Brief, Direction, and Prompt artifact flow.
 
 ## Node States
 


### PR DESCRIPTION
## Summary
- Documents Direction Set as a Facets domain grouping concept, not a fourth artifact type or React Flow-only state.
- Defines the v1 interaction model: Brief creates sets, Direction Set headers generate into sets.
- Documents append-by-default iteration and deferred drag-to-create/connect gestures.
- Updates #23 with the chosen implementation model while keeping it blocked on this issue.

## Issue
Addresses #22.

## Acceptance Criteria
- [x] Direction Set concept is documented in product terms.
- [x] Chosen v1 interaction model is documented.
- [x] Distinction between Direction Set domain data and React Flow rendering state is explicit.
- [x] Empty-state flow is defined.
- [x] Iteration flow is defined.
- [x] Deferred interactions are listed.
- [x] Follow-up implementation issue #23 is updated based on the decision.

## Validation
- [x] Manual docs link/reference check.
- [x] Confirmed docs-only changes.
- [x] No runtime code changes; npm build not required.

## Notes
The untracked `Design System/` folder was left untouched.