### PR TITLE
Implement Direction Set creation and generation workflow

### DIFF
--- a/docs/artifact-model.md
+++ b/docs/artifact-model.md
@@ -15,6 +15,7 @@ type FacetsProject = {
 
 type FacetsCanvas = {
   id: CanvasId;
+  directionSets: DirectionSet[];
   artifacts: FacetsArtifact[];
   relationships: FacetsRelationship[];
 };
@@ -69,8 +70,8 @@ Relationships are Facets domain objects, not React Flow edges:
 type FacetsRelationship = {
   id: RelationshipId;
   type: FacetsRelationshipType;
-  sourceId: ArtifactId;
-  targetId: ArtifactId;
+  sourceId: FacetsCanvasNodeId;
+  targetId: FacetsCanvasNodeId;
 };
 ```
 

--- a/docs/local-project-file.md
+++ b/docs/local-project-file.md
@@ -30,6 +30,7 @@ type FacetsProject = {
 
 type FacetsCanvas = {
   id: CanvasId;
+  directionSets: DirectionSet[];
   artifacts: FacetsArtifact[];
   relationships: FacetsRelationship[];
 };
@@ -41,7 +42,7 @@ Canvas rendering state is stored separately:
 type FacetsCanvasView = {
   canvasId: CanvasId;
   viewport: FacetsCanvasViewport;
-  nodes: Record<ArtifactId, FacetsCanvasNodeView>;
+  nodes: Record<FacetsCanvasNodeId, FacetsCanvasNodeView>;
 };
 
 type FacetsCanvasViewport = {
@@ -71,7 +72,7 @@ type FacetsCanvasNodeSize = {
 
 ## React Flow Boundary
 
-React Flow nodes are derived from `project.canvas.artifacts` plus `canvasView.nodes`.
+React Flow nodes are derived from `project.canvas.artifacts`, `project.canvas.directionSets`, and `canvasView.nodes`.
 
 React Flow edges are derived from `project.canvas.relationships`.
 
@@ -79,7 +80,7 @@ React Flow viewport is derived from `canvasView.viewport`.
 
 Raw React Flow state should not be serialized as the Facets project file format. React Flow can provide useful rendering details, but the saved file should preserve the Facets domain model and the minimum canvas view state needed to restore the workbench.
 
-Artifact content lives in `project.canvas.artifacts`. Relationship content lives in `project.canvas.relationships`. Viewport, position, size, and expanded state live in `canvasView`.
+Artifact content lives in `project.canvas.artifacts`. Direction Set grouping data lives in `project.canvas.directionSets`. Relationship content lives in `project.canvas.relationships`. Viewport, position, size, and expanded state live in `canvasView`.
 
 ## Example
 
@@ -94,6 +95,12 @@ The example below is illustrative documentation, not a committed sample file or 
     "name": "Homepage exploration",
     "canvas": {
       "id": "canvas-1",
+      "directionSets": [
+        {
+          "id": "direction-set-1",
+          "title": "Direction Set 1"
+        }
+      ],
       "artifacts": [
         {
           "id": "brief-1",
@@ -123,12 +130,18 @@ The example below is illustrative documentation, not a committed sample file or 
       "relationships": [
         {
           "id": "relationship-1",
-          "type": "brief_to_direction",
+          "type": "brief_to_direction_set",
           "sourceId": "brief-1",
-          "targetId": "direction-1"
+          "targetId": "direction-set-1"
         },
         {
           "id": "relationship-2",
+          "type": "contains_direction",
+          "sourceId": "direction-set-1",
+          "targetId": "direction-1"
+        },
+        {
+          "id": "relationship-3",
           "type": "direction_to_prompt",
           "sourceId": "direction-1",
           "targetId": "prompt-1"
@@ -155,10 +168,20 @@ The example below is illustrative documentation, not a committed sample file or 
           "height": 240
         }
       },
-      "direction-1": {
+      "direction-set-1": {
         "position": {
           "x": 420,
           "y": 0
+        },
+        "size": {
+          "width": 380,
+          "height": 308
+        }
+      },
+      "direction-1": {
+        "position": {
+          "x": 20,
+          "y": 64
         }
       },
       "prompt-1": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import type {
   ArtifactId,
   BriefArtifact,
   DirectionArtifact,
+  DirectionSetId,
   FacetsRelationship,
 } from "./domain";
 import { staticProjectFile } from "./fixtures/staticProject";
@@ -77,13 +78,22 @@ function App() {
   );
 
   const handleGenerateDirections = useCallback(
-    (sourceBriefId: ArtifactId) => {
+    (directionSetId: DirectionSetId) => {
+      const directionSet = project.canvas.directionSets.find(
+        (set) => set.id === directionSetId,
+      );
+      const sourceBriefRelationship = project.canvas.relationships.find(
+        (relationship) =>
+          relationship.type === "brief_to_direction_set" &&
+          relationship.targetId === directionSetId,
+      );
       const brief = project.canvas.artifacts.find(
         (artifact): artifact is BriefArtifact =>
-          artifact.id === sourceBriefId && artifact.type === "brief",
+          artifact.id === sourceBriefRelationship?.sourceId &&
+          artifact.type === "brief",
       );
 
-      if (!brief) {
+      if (!directionSet || !brief) {
         return;
       }
 
@@ -108,11 +118,16 @@ function App() {
           };
         },
       );
+      const existingDirectionSetCount = project.canvas.relationships.filter(
+        (relationship) =>
+          relationship.type === "contains_direction" &&
+          relationship.sourceId === directionSetId,
+      ).length;
       const generatedRelationships: FacetsRelationship[] =
         generatedDirections.map((direction) => ({
-          id: `relationship-${sourceBriefId}-${direction.id}`,
-          type: "brief_to_direction",
-          sourceId: sourceBriefId,
+          id: `relationship-${directionSetId}-${direction.id}`,
+          type: "contains_direction",
+          sourceId: directionSetId,
           targetId: direction.id,
         }));
 
@@ -133,7 +148,7 @@ function App() {
           ...canvasView.nodes,
           ...Object.fromEntries(
             generatedDirections.map((direction, index) => {
-              const generatedIndex = existingGeneratedCount + index;
+              const generatedIndex = existingDirectionSetCount + index;
 
               return [
                 direction.id,

--- a/src/canvas/DirectionGroupNode.tsx
+++ b/src/canvas/DirectionGroupNode.tsx
@@ -1,13 +1,30 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
+import type { MouseEvent } from "react";
 import type { DirectionGroupNode as DirectionGroupNodeType } from "./types";
 
 function DirectionGroupNode({ data }: NodeProps<DirectionGroupNodeType>) {
+  const buttonLabel = data.count === 0 ? "Generate directions" : "Generate more";
+
+  function handleGenerateClick(event: MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+    data.onGenerateDirections?.(data.directionSet.id);
+  }
+
   return (
     <section className="direction-group-node">
       <Handle type="target" position={Position.Left} isConnectable={false} />
       <header className="direction-group-node__header">
-        <span>{data.title}</span>
-        <span>{data.count}</span>
+        <div className="direction-group-node__title">
+          <span>{data.directionSet.title}</span>
+          <span>{data.count}</span>
+        </div>
+        <button
+          className="direction-group-node__action nodrag nopan"
+          type="button"
+          onClick={handleGenerateClick}
+        >
+          {buttonLabel}
+        </button>
       </header>
     </section>
   );

--- a/src/canvas/RelationshipEdge.tsx
+++ b/src/canvas/RelationshipEdge.tsx
@@ -1,10 +1,8 @@
 import {
   BaseEdge,
-  EdgeLabelRenderer,
   getSmoothStepPath,
   type EdgeProps,
 } from "@xyflow/react";
-import type { MouseEvent } from "react";
 import type { RelationshipEdge as RelationshipEdgeType } from "./types";
 
 function RelationshipEdge({
@@ -16,9 +14,8 @@ function RelationshipEdge({
   sourcePosition,
   targetPosition,
   label,
-  data,
 }: EdgeProps<RelationshipEdgeType>) {
-  const [edgePath, labelX, labelY] = getSmoothStepPath({
+  const [edgePath] = getSmoothStepPath({
     sourceX,
     sourceY,
     sourcePosition,
@@ -27,41 +24,7 @@ function RelationshipEdge({
     targetPosition,
   });
 
-  function handleGenerateClick(event: MouseEvent<HTMLButtonElement>) {
-    event.stopPropagation();
-
-    if (data?.sourceBriefId) {
-      data.onGenerateDirections?.(data.sourceBriefId);
-    }
-  }
-
-  return (
-    <>
-      <BaseEdge
-        id={id}
-        path={edgePath}
-        label={data?.showGenerateDirections ? undefined : label}
-      />
-      {data?.showGenerateDirections ? (
-        <EdgeLabelRenderer>
-          <div
-            className="relationship-edge__label nodrag nopan"
-            style={{
-              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-            }}
-          >
-            <button
-              className="relationship-edge__button"
-              type="button"
-              onClick={handleGenerateClick}
-            >
-              Generate directions
-            </button>
-          </div>
-        </EdgeLabelRenderer>
-      ) : null}
-    </>
-  );
+  return <BaseEdge id={id} path={edgePath} label={label} />;
 }
 
 export default RelationshipEdge;

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -1,7 +1,9 @@
 import type {
   ArtifactId,
-  FacetsCanvasView,
+  DirectionSet,
+  DirectionSetId,
   FacetsArtifact,
+  FacetsCanvasView,
   FacetsProject,
   FacetsProjectFile,
   FacetsRelationship,
@@ -16,13 +18,9 @@ import type {
   RelationshipEdge,
 } from "./types";
 
-const GENERATED_DIRECTIONS_GROUP_ID = "generated-directions-group";
-const GENERATED_DIRECTION_GROUP_X = 420;
-const GENERATED_DIRECTION_GROUP_Y = 0;
-const GENERATED_DIRECTION_GROUP_WIDTH = 380;
-const GENERATED_DIRECTION_GROUP_ROW_HEIGHT = 260;
-const GENERATED_DIRECTION_GROUP_BASE_HEIGHT = 48;
-const generatedDirectionIdPattern = /^direction-generated-\d+$/;
+const DIRECTION_SET_WIDTH = 380;
+const DIRECTION_SET_ROW_HEIGHT = 260;
+const DIRECTION_SET_BASE_HEIGHT = 48;
 
 export type FacetsReactFlowGraph = {
   nodes: FacetsCanvasNode[];
@@ -34,7 +32,7 @@ export type MapProjectFileToReactFlowOptions = {
   canvasView?: FacetsCanvasView;
   onToggleExpanded?: (artifactId: ArtifactId) => void;
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void;
-  onGenerateDirections?: (sourceBriefId: ArtifactId) => void;
+  onGenerateDirections?: (directionSetId: DirectionSetId) => void;
 };
 
 export function mapProjectFileToReactFlow(
@@ -43,91 +41,80 @@ export function mapProjectFileToReactFlow(
 ): FacetsReactFlowGraph {
   const project = options.project ?? projectFile.project;
   const canvasView = options.canvasView ?? projectFile.canvasView;
-  const artifactsById = new Map(
-    project.canvas.artifacts.map((artifact) => [artifact.id, artifact]),
+  const directionSetByDirectionId = getDirectionSetByDirectionId(
+    project.canvas.relationships,
   );
-  const generateDirectionsRelationshipId = project.canvas.relationships.find(
-    (relationship) =>
-      relationship.type === "brief_to_direction" &&
-      artifactsById.get(relationship.sourceId)?.type === "brief",
-  )?.id;
-  const sourceBrief = project.canvas.artifacts.find(
-    (artifact) => artifact.type === "brief",
-  );
-
-  const generatedDirectionCount = project.canvas.artifacts.filter(
-    isGeneratedDirectionArtifact,
-  ).length;
-  const generatedDirectionRelationships = project.canvas.relationships.filter(
-    (relationship) =>
-      relationship.type === "brief_to_direction" &&
-      isGeneratedDirectionArtifact(artifactsById.get(relationship.targetId)),
-  );
-  const generatedDirectionGroupEdge =
-    generatedDirectionCount > 0 && generatedDirectionRelationships.length > 0
-      ? [
-          mapGeneratedDirectionsGroupEdge(
-            generatedDirectionRelationships[0],
-            options.onGenerateDirections,
-          ),
-        ]
-      : sourceBrief
-        ? [
-            mapEmptyGeneratedDirectionsGroupEdge(
-              sourceBrief.id,
-              options.onGenerateDirections,
-            ),
-          ]
-        : [];
 
   return {
     nodes: [
-      mapGeneratedDirectionsGroupNode(generatedDirectionCount),
+      ...project.canvas.directionSets.map((directionSet) =>
+        mapDirectionSetToNode(
+          directionSet,
+          canvasView,
+          getDirectionCount(directionSet.id, project.canvas.relationships),
+          options.onGenerateDirections,
+        ),
+      ),
       ...project.canvas.artifacts.map((artifact) =>
         mapArtifactToNode(
           artifact,
           canvasView,
+          directionSetByDirectionId.get(artifact.id),
           options.onToggleExpanded,
           options.onUpdateBrief,
         ),
       ),
     ],
-    edges: [
-      ...project.canvas.relationships
-        .filter(
-          (relationship) =>
-            !isGeneratedDirectionArtifact(
-              artifactsById.get(relationship.targetId),
-            ),
-        )
-        .map((relationship) =>
-          mapRelationshipToEdge(
-            relationship,
-            generatedDirectionCount === 0 && !sourceBrief &&
-              relationship.id === generateDirectionsRelationshipId,
-            options.onGenerateDirections,
-          ),
-      ),
-      ...generatedDirectionGroupEdge,
-    ],
+    edges: project.canvas.relationships
+      .filter((relationship) => relationship.type !== "contains_direction")
+      .map(mapRelationshipToEdge),
+  };
+}
+
+function mapDirectionSetToNode(
+  directionSet: DirectionSet,
+  canvasView: FacetsCanvasView,
+  directionCount: number,
+  onGenerateDirections?: (directionSetId: DirectionSetId) => void,
+): DirectionGroupNode {
+  const nodeView = canvasView.nodes[directionSet.id];
+
+  return {
+    id: directionSet.id,
+    type: "directionGroup",
+    position: nodeView.position,
+    data: {
+      directionSet,
+      count: directionCount,
+      onGenerateDirections,
+    },
+    draggable: false,
+    selectable: false,
+    zIndex: 1,
+    style: {
+      width: nodeView.size?.width ?? DIRECTION_SET_WIDTH,
+      height:
+        DIRECTION_SET_BASE_HEIGHT +
+        Math.max(directionCount, 1) * DIRECTION_SET_ROW_HEIGHT,
+    },
   };
 }
 
 function mapArtifactToNode(
   artifact: FacetsArtifact,
   canvasView: FacetsCanvasView,
+  parentDirectionSetId: DirectionSetId | undefined,
   onToggleExpanded?: (artifactId: ArtifactId) => void,
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void,
 ): ArtifactNode {
   const nodeView = canvasView.nodes[artifact.id];
-  const isGeneratedDirection = isGeneratedDirectionArtifact(artifact);
 
   return {
     id: artifact.id,
     type: "artifact",
     position: nodeView.position,
-    parentId: isGeneratedDirection ? GENERATED_DIRECTIONS_GROUP_ID : undefined,
-    extent: isGeneratedDirection ? "parent" : undefined,
+    parentId: parentDirectionSetId,
+    extent: parentDirectionSetId ? "parent" : undefined,
     data: getArtifactNodeData(
       artifact,
       Boolean(nodeView.expanded),
@@ -146,81 +133,29 @@ function mapArtifactToNode(
   };
 }
 
-function mapGeneratedDirectionsGroupNode(
-  generatedDirectionCount: number,
-): DirectionGroupNode {
-  return {
-    id: GENERATED_DIRECTIONS_GROUP_ID,
-    type: "directionGroup",
-    position: {
-      x: GENERATED_DIRECTION_GROUP_X,
-      y: GENERATED_DIRECTION_GROUP_Y,
-    },
-    data: {
-      title: "Generated directions",
-      count: generatedDirectionCount,
-    },
-    draggable: false,
-    selectable: false,
-    zIndex: 1,
-    style: {
-      width: GENERATED_DIRECTION_GROUP_WIDTH,
-      height:
-        GENERATED_DIRECTION_GROUP_BASE_HEIGHT +
-        Math.max(generatedDirectionCount, 1) *
-          GENERATED_DIRECTION_GROUP_ROW_HEIGHT,
-    },
-  };
+function getDirectionSetByDirectionId(
+  relationships: FacetsRelationship[],
+): Map<ArtifactId, DirectionSetId> {
+  const directionSetByDirectionId = new Map<ArtifactId, DirectionSetId>();
+
+  relationships.forEach((relationship) => {
+    if (relationship.type === "contains_direction") {
+      directionSetByDirectionId.set(relationship.targetId, relationship.sourceId);
+    }
+  });
+
+  return directionSetByDirectionId;
 }
 
-function mapGeneratedDirectionsGroupEdge(
-  relationship: FacetsRelationship,
-  onGenerateDirections?: (sourceBriefId: ArtifactId) => void,
-): RelationshipEdge {
-  return {
-    id: `relationship-${relationship.sourceId}-${GENERATED_DIRECTIONS_GROUP_ID}`,
-    type: "relationship",
-    source: relationship.sourceId,
-    target: GENERATED_DIRECTIONS_GROUP_ID,
-    label: "Generated directions",
-    data: {
-      relationship,
-      sourceBriefId: relationship.sourceId,
-      showGenerateDirections: true,
-      onGenerateDirections,
-    },
-    selectable: false,
-    reconnectable: false,
-  };
-}
-
-function mapEmptyGeneratedDirectionsGroupEdge(
-  sourceBriefId: ArtifactId,
-  onGenerateDirections?: (sourceBriefId: ArtifactId) => void,
-): RelationshipEdge {
-  return {
-    id: `relationship-${sourceBriefId}-${GENERATED_DIRECTIONS_GROUP_ID}`,
-    type: "relationship",
-    source: sourceBriefId,
-    target: GENERATED_DIRECTIONS_GROUP_ID,
-    label: "Generated directions",
-    data: {
-      sourceBriefId,
-      showGenerateDirections: true,
-      onGenerateDirections,
-    },
-    selectable: false,
-    reconnectable: false,
-  };
-}
-
-function isGeneratedDirectionArtifact(
-  artifact: FacetsArtifact | undefined,
-): boolean {
-  return (
-    artifact?.type === "direction" &&
-    generatedDirectionIdPattern.test(artifact.id)
-  );
+function getDirectionCount(
+  directionSetId: DirectionSetId,
+  relationships: FacetsRelationship[],
+): number {
+  return relationships.filter(
+    (relationship) =>
+      relationship.type === "contains_direction" &&
+      relationship.sourceId === directionSetId,
+  ).length;
 }
 
 function getArtifactNodeData(
@@ -260,8 +195,6 @@ function getArtifactNodeData(
 
 function mapRelationshipToEdge(
   relationship: FacetsRelationship,
-  showGenerateDirections: boolean,
-  onGenerateDirections?: (sourceBriefId: ArtifactId) => void,
 ): RelationshipEdge {
   return {
     id: relationship.id,
@@ -269,11 +202,7 @@ function mapRelationshipToEdge(
     source: relationship.sourceId,
     target: relationship.targetId,
     label: getRelationshipLabel(relationship),
-    data: {
-      relationship,
-      showGenerateDirections,
-      onGenerateDirections,
-    },
+    data: { relationship },
     selectable: false,
     reconnectable: false,
   };
@@ -282,6 +211,10 @@ function mapRelationshipToEdge(
 function getRelationshipLabel(relationship: FacetsRelationship): string {
   switch (relationship.type) {
     case "brief_to_direction":
+      return "Direction";
+    case "brief_to_direction_set":
+      return "Direction Set";
+    case "contains_direction":
       return "Direction";
     case "direction_to_prompt":
       return "Prompt";

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -2,6 +2,8 @@ import type { Edge, Node } from "@xyflow/react";
 import type {
   ArtifactId,
   BriefArtifact,
+  DirectionSet,
+  DirectionSetId,
   FacetsArtifact,
   FacetsRelationship,
 } from "../domain";
@@ -22,8 +24,9 @@ export type ArtifactNodeData = {
 export type ArtifactNode = Node<ArtifactNodeData, "artifact">;
 
 export type DirectionGroupNodeData = {
-  title: string;
+  directionSet: DirectionSet;
   count: number;
+  onGenerateDirections?: (directionSetId: DirectionSetId) => void;
 };
 
 export type DirectionGroupNode = Node<
@@ -34,10 +37,7 @@ export type DirectionGroupNode = Node<
 export type FacetsCanvasNode = ArtifactNode | DirectionGroupNode;
 
 export type RelationshipEdgeData = {
-  relationship?: FacetsRelationship;
-  sourceBriefId?: ArtifactId;
-  showGenerateDirections?: boolean;
-  onGenerateDirections?: (sourceBriefId: ArtifactId) => void;
+  relationship: FacetsRelationship;
 };
 
 export type RelationshipEdge = Edge<RelationshipEdgeData, "relationship">;

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,7 +1,9 @@
 export type ProjectId = string;
 export type CanvasId = string;
 export type ArtifactId = string;
+export type DirectionSetId = string;
 export type RelationshipId = string;
+export type FacetsCanvasNodeId = ArtifactId | DirectionSetId;
 
 export type FacetsProject = {
   id: ProjectId;
@@ -11,6 +13,7 @@ export type FacetsProject = {
 
 export type FacetsCanvas = {
   id: CanvasId;
+  directionSets: DirectionSet[];
   artifacts: FacetsArtifact[];
   relationships: FacetsRelationship[];
 };
@@ -25,7 +28,7 @@ export type FacetsProjectFile = {
 export type FacetsCanvasView = {
   canvasId: CanvasId;
   viewport: FacetsCanvasViewport;
-  nodes: Record<ArtifactId, FacetsCanvasNodeView>;
+  nodes: Record<FacetsCanvasNodeId, FacetsCanvasNodeView>;
 };
 
 export type FacetsCanvasViewport = {
@@ -68,6 +71,11 @@ export type DirectionArtifact = {
   rationale?: string;
 };
 
+export type DirectionSet = {
+  id: DirectionSetId;
+  title: string;
+};
+
 export type PromptTarget = "chatgpt" | "codex" | "figma_mcp" | "generic";
 
 export type PromptArtifact = {
@@ -86,12 +94,14 @@ export type FacetsArtifact =
 
 export type FacetsRelationshipType =
   | "brief_to_direction"
+  | "brief_to_direction_set"
+  | "contains_direction"
   | "direction_to_prompt"
   | "prompt_sequence";
 
 export type FacetsRelationship = {
   id: RelationshipId;
   type: FacetsRelationshipType;
-  sourceId: ArtifactId;
-  targetId: ArtifactId;
+  sourceId: FacetsCanvasNodeId;
+  targetId: FacetsCanvasNodeId;
 };

--- a/src/fixtures/staticProject.ts
+++ b/src/fixtures/staticProject.ts
@@ -8,6 +8,12 @@ export const staticProjectFile: FacetsProjectFile = {
     name: "Homepage exploration",
     canvas: {
       id: "canvas-static-homepage",
+      directionSets: [
+        {
+          id: "direction-set-static-1",
+          title: "Direction Set 1",
+        },
+      ],
       artifacts: [
         {
           id: "brief-static-homepage",
@@ -20,7 +26,14 @@ export const staticProjectFile: FacetsProjectFile = {
             "Keep it practical, canvas-first, and focused on better prompts for design agents.",
         },
       ],
-      relationships: [],
+      relationships: [
+        {
+          id: "relationship-static-brief-direction-set",
+          type: "brief_to_direction_set",
+          sourceId: "brief-static-homepage",
+          targetId: "direction-set-static-1",
+        },
+      ],
     },
   },
   canvasView: {
@@ -35,6 +48,10 @@ export const staticProjectFile: FacetsProjectFile = {
         expanded: false,
         position: { x: 0, y: 0 },
         size: { width: 320, height: 220 },
+      },
+      "direction-set-static-1": {
+        position: { x: 420, y: 0 },
+        size: { width: 380, height: 308 },
       },
     },
   },

--- a/src/styles.css
+++ b/src/styles.css
@@ -60,43 +60,13 @@ body {
   letter-spacing: 0;
 }
 
-.relationship-edge__label {
-  position: absolute;
-  pointer-events: all;
-}
-
-.relationship-edge__button {
-  min-height: 30px;
-  padding: 0 12px;
-  color: #fffdf7;
-  font: inherit;
-  font-size: 12px;
-  font-weight: 750;
-  letter-spacing: 0;
-  white-space: nowrap;
-  background: #1f7c60;
-  border: 1px solid rgba(31, 35, 32, 0.1);
-  border-radius: 7px;
-  box-shadow: 0 10px 24px rgba(54, 48, 36, 0.16);
-  cursor: pointer;
-}
-
-.relationship-edge__button:hover {
-  background: #18684f;
-}
-
-.relationship-edge__button:focus-visible {
-  outline: 3px solid rgba(31, 124, 96, 0.24);
-  outline-offset: 2px;
-}
-
 .react-flow__node {
   z-index: 2;
   pointer-events: all !important;
 }
 
 .react-flow__node-directionGroup {
-  pointer-events: none !important;
+  pointer-events: all !important;
 }
 
 .direction-group-node {
@@ -112,6 +82,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
   min-height: 28px;
   padding: 0 4px;
   color: #586383;
@@ -119,6 +90,41 @@ body {
   font-weight: 800;
   letter-spacing: 0;
   text-transform: uppercase;
+}
+
+.direction-group-node__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.direction-group-node__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  min-height: 28px;
+  padding: 0 11px;
+  color: #fffdf7;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0;
+  text-transform: none;
+  white-space: nowrap;
+  background: #586383;
+  border: 1px solid rgba(31, 35, 32, 0.1);
+  border-radius: 7px;
+  cursor: pointer;
+}
+
+.direction-group-node__action:hover {
+  background: #48526f;
+}
+
+.direction-group-node__action:focus-visible {
+  outline: 3px solid rgba(88, 99, 131, 0.24);
+  outline-offset: 2px;
 }
 
 .artifact-node,


### PR DESCRIPTION
## Summary
- Model Direction Sets as saved canvas domain data with `directionSets` on the Facets canvas.
- Render Direction Sets from domain data and connect the Brief to the set with `brief_to_direction_set`.
- Generate deterministic Direction artifacts into the clicked set with hidden `contains_direction` relationships and React Flow parent containment.
- Update docs for the artifact model and local project file shape.

## Issue #23 Acceptance Criteria
- [x] Direction Sets are saved canvas domain data, not artifacts and not React Flow-only groups.
- [x] `brief_to_direction_set` renders as the visible edge.
- [x] `contains_direction` relationships do not render as visible edges.
- [x] Direction membership is represented with React Flow parent/group containment derived from Facets relationships.
- [x] Initial fixture has one Brief, one empty `Direction Set 1`, and one Brief-to-set relationship.
- [x] Direction Set headers show title, contained Direction count, and the correct generation action copy.
- [x] Generation appends three deterministic Direction artifacts to the clicked set only.
- [x] Generated Direction IDs are globally sequential.
- [x] Generated cards are positioned inside the target set without overlap.

## Validation
- [x] `npm run build`
- [x] `git diff --check`
- [x] Confirmed `src/domain` has no React or `@xyflow/react` imports.
- [x] Browser validation on `http://127.0.0.1:1421/`: initial empty set, generate to 3, generate more to 6, one visible Brief-to-set edge, no visible `contains_direction` edges, deterministic generated positions, and no browser console errors.

Refs #23