### PR TITLE
Add create Direction Set workflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import {
   Background,
   Controls,
+  Panel,
   ReactFlow,
   type EdgeTypes,
   type NodeTypes,
@@ -16,6 +17,7 @@ import type {
   ArtifactId,
   BriefArtifact,
   DirectionArtifact,
+  DirectionSet,
   DirectionSetId,
   FacetsRelationship,
 } from "./domain";
@@ -28,7 +30,13 @@ const GENERATED_DIRECTION_START_Y = 64;
 const GENERATED_DIRECTION_Y_GAP = 260;
 const GENERATED_DIRECTION_WIDTH = 340;
 const GENERATED_DIRECTION_HEIGHT = 220;
+const DIRECTION_SET_X = 420;
+const DIRECTION_SET_WIDTH = 380;
+const DIRECTION_SET_BASE_HEIGHT = 48;
+const DIRECTION_SET_ROW_HEIGHT = 260;
+const DIRECTION_SET_Y_GAP = 80;
 const generatedDirectionIdPattern = /^direction-generated-(\d+)$/;
+const generatedDirectionSetIdPattern = /^direction-set-generated-(\d+)$/;
 
 const nodeTypes = {
   artifact: ArtifactNode,
@@ -174,6 +182,58 @@ function App() {
     [canvasView, project],
   );
 
+  const handleCreateDirectionSet = useCallback(() => {
+    const existingGeneratedSetCount = project.canvas.directionSets.filter(
+      (directionSet) => generatedDirectionSetIdPattern.test(directionSet.id),
+    ).length;
+    const directionSetNumber = project.canvas.directionSets.length + 1;
+    const directionSet: DirectionSet = {
+      id: `direction-set-generated-${existingGeneratedSetCount + 1}`,
+      title: `Direction Set ${directionSetNumber}`,
+    };
+    const nextY =
+      project.canvas.directionSets.length === 0
+        ? 0
+        : Math.max(
+            ...project.canvas.directionSets.map((existingDirectionSet) => {
+              const nodeView = canvasView.nodes[existingDirectionSet.id];
+              const directionCount = project.canvas.relationships.filter(
+                (relationship) =>
+                  relationship.type === "contains_direction" &&
+                  relationship.sourceId === existingDirectionSet.id,
+              ).length;
+              const groupHeight =
+                DIRECTION_SET_BASE_HEIGHT +
+                Math.max(directionCount, 1) * DIRECTION_SET_ROW_HEIGHT;
+
+              return nodeView.position.y + groupHeight;
+            }),
+          ) + DIRECTION_SET_Y_GAP;
+
+    setProject({
+      ...project,
+      canvas: {
+        ...project.canvas,
+        directionSets: [...project.canvas.directionSets, directionSet],
+      },
+    });
+    setCanvasView({
+      ...canvasView,
+      nodes: {
+        ...canvasView.nodes,
+        [directionSet.id]: {
+          position: { x: DIRECTION_SET_X, y: nextY },
+          size: {
+            width: DIRECTION_SET_WIDTH,
+            height:
+              DIRECTION_SET_BASE_HEIGHT +
+              DIRECTION_SET_ROW_HEIGHT,
+          },
+        },
+      },
+    });
+  }, [canvasView, project]);
+
   const staticGraph = useMemo(
     () =>
       mapProjectFileToReactFlow(staticProjectFile, {
@@ -206,6 +266,15 @@ function App() {
         edgesReconnectable={false}
         deleteKeyCode={null}
       >
+        <Panel position="top-left" className="canvas-toolbar">
+          <button
+            className="canvas-toolbar__button nodrag nopan"
+            type="button"
+            onClick={handleCreateDirectionSet}
+          >
+            New direction set
+          </button>
+        </Panel>
         <Background />
         <Controls />
       </ReactFlow>

--- a/src/canvas/DirectionGroupNode.tsx
+++ b/src/canvas/DirectionGroupNode.tsx
@@ -3,10 +3,18 @@ import type { MouseEvent } from "react";
 import type { DirectionGroupNode as DirectionGroupNodeType } from "./types";
 
 function DirectionGroupNode({ data }: NodeProps<DirectionGroupNodeType>) {
-  const buttonLabel = data.count === 0 ? "Generate directions" : "Generate more";
+  const buttonLabel = !data.canGenerate
+    ? "Connect brief to generate"
+    : data.count === 0
+      ? "Generate directions"
+      : "Generate more";
 
   function handleGenerateClick(event: MouseEvent<HTMLButtonElement>) {
     event.stopPropagation();
+    if (!data.canGenerate) {
+      return;
+    }
+
     data.onGenerateDirections?.(data.directionSet.id);
   }
 
@@ -21,6 +29,7 @@ function DirectionGroupNode({ data }: NodeProps<DirectionGroupNodeType>) {
         <button
           className="direction-group-node__action nodrag nopan"
           type="button"
+          disabled={!data.canGenerate}
           onClick={handleGenerateClick}
         >
           {buttonLabel}

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -52,6 +52,7 @@ export function mapProjectFileToReactFlow(
           directionSet,
           canvasView,
           getDirectionCount(directionSet.id, project.canvas.relationships),
+          isDirectionSetConnected(directionSet.id, project.canvas.relationships),
           options.onGenerateDirections,
         ),
       ),
@@ -75,6 +76,7 @@ function mapDirectionSetToNode(
   directionSet: DirectionSet,
   canvasView: FacetsCanvasView,
   directionCount: number,
+  canGenerate: boolean,
   onGenerateDirections?: (directionSetId: DirectionSetId) => void,
 ): DirectionGroupNode {
   const nodeView = canvasView.nodes[directionSet.id];
@@ -86,6 +88,7 @@ function mapDirectionSetToNode(
     data: {
       directionSet,
       count: directionCount,
+      canGenerate,
       onGenerateDirections,
     },
     draggable: false,
@@ -156,6 +159,17 @@ function getDirectionCount(
       relationship.type === "contains_direction" &&
       relationship.sourceId === directionSetId,
   ).length;
+}
+
+function isDirectionSetConnected(
+  directionSetId: DirectionSetId,
+  relationships: FacetsRelationship[],
+): boolean {
+  return relationships.some(
+    (relationship) =>
+      relationship.type === "brief_to_direction_set" &&
+      relationship.targetId === directionSetId,
+  );
 }
 
 function getArtifactNodeData(

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -26,6 +26,7 @@ export type ArtifactNode = Node<ArtifactNodeData, "artifact">;
 export type DirectionGroupNodeData = {
   directionSet: DirectionSet;
   count: number;
+  canGenerate: boolean;
   onGenerateDirections?: (directionSetId: DirectionSetId) => void;
 };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -69,6 +69,44 @@ body {
   pointer-events: all !important;
 }
 
+.canvas-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  background: rgba(255, 253, 247, 0.84);
+  border: 1px solid rgba(31, 35, 32, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 14px 36px rgba(54, 48, 36, 0.1);
+  backdrop-filter: blur(8px);
+}
+
+.canvas-toolbar__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  padding: 0 12px;
+  color: #fffdf7;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 750;
+  letter-spacing: 0;
+  background: #1f7c60;
+  border: 1px solid rgba(31, 35, 32, 0.1);
+  border-radius: 7px;
+  cursor: pointer;
+}
+
+.canvas-toolbar__button:hover {
+  background: #176b52;
+}
+
+.canvas-toolbar__button:focus-visible {
+  outline: 3px solid rgba(31, 124, 96, 0.24);
+  outline-offset: 2px;
+}
+
 .direction-group-node {
   width: 100%;
   height: 100%;
@@ -120,6 +158,14 @@ body {
 
 .direction-group-node__action:hover {
   background: #48526f;
+}
+
+.direction-group-node__action:disabled,
+.direction-group-node__action:disabled:hover {
+  color: #6d6a61;
+  background: #f2eee3;
+  border-color: rgba(31, 35, 32, 0.12);
+  cursor: default;
 }
 
 .direction-group-node__action:focus-visible {


### PR DESCRIPTION
## Summary
- Add a canvas toolbar action for creating additional Direction Sets.
- New Direction Sets are saved in Facets canvas domain data and canvas view state.
- New sets start unconnected and show disabled `Connect brief to generate` copy.

## Issue #26 Acceptance Criteria
- [x] A user can create a second Direction Set from a canvas toolbar.
- [x] The new Direction Set is added to `project.canvas.directionSets`.
- [x] The new Direction Set has no automatic `brief_to_direction_set` relationship.
- [x] The new Direction Set has a `canvasView.nodes` entry with deterministic non-overlapping position and size.
- [x] The new Direction Set starts empty, shows count `0`, and shows disabled `Connect brief to generate` copy.
- [x] Existing connected Direction Sets still show `Generate directions` when empty and `Generate more` when populated.
- [x] Clicking generation in an existing connected set still adds three Direction artifacts to that set only.
- [x] Existing Direction Sets and their contained Directions remain unchanged when a new unconnected set is created.
- [x] Direction Set IDs and titles are deterministic.
- [x] No persistence, API/model calls, prompt copy/export, side panel, modal, inspector, fullscreen editor, drag-to-connect workflow, or Figma MCP behavior is introduced.
- [x] `src/domain` remains free of React and `@xyflow/react` imports.

## Validation
- [x] `npm run build`
- [x] `git diff --check HEAD`
- [x] Confirmed `src/domain` has no React or `@xyflow/react` imports.
- [x] Browser validation on `http://127.0.0.1:1421/`: initial canvas has one connected set; toolbar creates unconnected Set 2 at a non-overlapping position; Set 2 generation is disabled; Set 1 still generates three Directions into itself; only the Brief-to-Set 1 edge is visible; no browser console errors beyond normal Vite/React dev messages.

Refs #26