### PR TITLE
Add editable Direction node fields

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import ArtifactNode from "./canvas/ArtifactNode";
 import DirectionGroupNode from "./canvas/DirectionGroupNode";
 import { mapProjectFileToReactFlow } from "./canvas/mapFacetsToReactFlow";
 import RelationshipEdge from "./canvas/RelationshipEdge";
-import type { BriefArtifactPatch } from "./canvas/types";
+import type { BriefArtifactPatch, DirectionArtifactPatch } from "./canvas/types";
 import type {
   ArtifactId,
   BriefArtifact,
@@ -76,6 +76,23 @@ function App() {
           ...currentProject.canvas,
           artifacts: currentProject.canvas.artifacts.map((artifact) =>
             artifact.id === artifactId && artifact.type === "brief"
+              ? { ...artifact, ...patch }
+              : artifact,
+          ),
+        },
+      }));
+    },
+    [],
+  );
+
+  const handleUpdateDirection = useCallback(
+    (artifactId: ArtifactId, patch: DirectionArtifactPatch) => {
+      setProject((currentProject) => ({
+        ...currentProject,
+        canvas: {
+          ...currentProject.canvas,
+          artifacts: currentProject.canvas.artifacts.map((artifact) =>
+            artifact.id === artifactId && artifact.type === "direction"
               ? { ...artifact, ...patch }
               : artifact,
           ),
@@ -241,6 +258,7 @@ function App() {
         canvasView,
         onToggleExpanded: handleToggleExpanded,
         onUpdateBrief: handleUpdateBrief,
+        onUpdateDirection: handleUpdateDirection,
         onGenerateDirections: handleGenerateDirections,
       }),
     [
@@ -248,6 +266,7 @@ function App() {
       handleGenerateDirections,
       handleToggleExpanded,
       handleUpdateBrief,
+      handleUpdateDirection,
       project,
     ],
   );

--- a/src/canvas/ArtifactNode.tsx
+++ b/src/canvas/ArtifactNode.tsx
@@ -4,6 +4,7 @@ import { getPromptTargetLabel } from "./mapFacetsToReactFlow";
 import type {
   ArtifactNode as ArtifactNodeType,
   BriefArtifactPatch,
+  DirectionArtifactPatch,
 } from "./types";
 
 function ArtifactNode({ data }: NodeProps<ArtifactNodeType>) {
@@ -45,6 +46,15 @@ function ArtifactNodeBody({ data }: Pick<ArtifactNodeType, "data">) {
       <EditableBriefFields
         artifact={data.artifact}
         onUpdateBrief={data.onUpdateBrief}
+      />
+    );
+  }
+
+  if (data.artifact.type === "direction" && data.expanded) {
+    return (
+      <EditableDirectionFields
+        artifact={data.artifact}
+        onUpdateDirection={data.onUpdateDirection}
       />
     );
   }
@@ -109,6 +119,64 @@ function EditableBriefFields({
           className="artifact-node__textarea nodrag nopan"
           value={artifact.constraints}
           onChange={(event) => handleChange("constraints", event)}
+          rows={3}
+        />
+      </label>
+    </div>
+  );
+}
+
+function EditableDirectionFields({
+  artifact,
+  onUpdateDirection,
+}: Pick<ArtifactNodeType["data"], "onUpdateDirection"> & {
+  artifact: Extract<
+    ArtifactNodeType["data"]["artifact"],
+    { type: "direction" }
+  >;
+}) {
+  function handleChange<K extends keyof DirectionArtifactPatch>(
+    field: K,
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) {
+    onUpdateDirection?.(artifact.id, { [field]: event.target.value });
+  }
+
+  return (
+    <div className="artifact-node__editor">
+      <label className="artifact-node__edit-field">
+        <span>Title</span>
+        <input
+          className="artifact-node__input nodrag nopan"
+          type="text"
+          value={artifact.title}
+          onChange={(event) => handleChange("title", event)}
+        />
+      </label>
+      <label className="artifact-node__edit-field">
+        <span>Angle</span>
+        <textarea
+          className="artifact-node__textarea nodrag nopan"
+          value={artifact.angle}
+          onChange={(event) => handleChange("angle", event)}
+          rows={3}
+        />
+      </label>
+      <label className="artifact-node__edit-field">
+        <span>Notes</span>
+        <textarea
+          className="artifact-node__textarea nodrag nopan"
+          value={artifact.notes}
+          onChange={(event) => handleChange("notes", event)}
+          rows={4}
+        />
+      </label>
+      <label className="artifact-node__edit-field">
+        <span>Rationale</span>
+        <textarea
+          className="artifact-node__textarea nodrag nopan"
+          value={artifact.rationale ?? ""}
+          onChange={(event) => handleChange("rationale", event)}
           rows={3}
         />
       </label>

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -1,5 +1,6 @@
 import type {
   ArtifactId,
+  DirectionArtifact,
   DirectionSet,
   DirectionSetId,
   FacetsArtifact,
@@ -21,7 +22,9 @@ import type {
 
 const DIRECTION_SET_WIDTH = 380;
 const DIRECTION_SET_ROW_HEIGHT = 260;
+const DIRECTION_SET_EXPANDED_ROW_HEIGHT = 540;
 const DIRECTION_SET_BASE_HEIGHT = 48;
+const DIRECTION_SET_CHILD_START_Y = 64;
 
 export type FacetsReactFlowGraph = {
   nodes: FacetsCanvasNode[];
@@ -49,6 +52,11 @@ export function mapProjectFileToReactFlow(
   const directionSetByDirectionId = getDirectionSetByDirectionId(
     project.canvas.relationships,
   );
+  const directionSetLayout = getDirectionSetLayout(
+    project.canvas.artifacts,
+    project.canvas.relationships,
+    canvasView,
+  );
 
   return {
     nodes: [
@@ -57,6 +65,7 @@ export function mapProjectFileToReactFlow(
           directionSet,
           canvasView,
           getDirectionCount(directionSet.id, project.canvas.relationships),
+          directionSetLayout.groupHeights.get(directionSet.id),
           isDirectionSetConnected(directionSet.id, project.canvas.relationships),
           options.onGenerateDirections,
         ),
@@ -66,6 +75,7 @@ export function mapProjectFileToReactFlow(
           artifact,
           canvasView,
           directionSetByDirectionId.get(artifact.id),
+          directionSetLayout.childPositions.get(artifact.id),
           options.onToggleExpanded,
           options.onUpdateBrief,
           options.onUpdateDirection,
@@ -82,6 +92,7 @@ function mapDirectionSetToNode(
   directionSet: DirectionSet,
   canvasView: FacetsCanvasView,
   directionCount: number,
+  groupHeight: number | undefined,
   canGenerate: boolean,
   onGenerateDirections?: (directionSetId: DirectionSetId) => void,
 ): DirectionGroupNode {
@@ -103,8 +114,9 @@ function mapDirectionSetToNode(
     style: {
       width: nodeView.size?.width ?? DIRECTION_SET_WIDTH,
       height:
+        groupHeight ??
         DIRECTION_SET_BASE_HEIGHT +
-        Math.max(directionCount, 1) * DIRECTION_SET_ROW_HEIGHT,
+          Math.max(directionCount, 1) * DIRECTION_SET_ROW_HEIGHT,
     },
   };
 }
@@ -113,6 +125,12 @@ function mapArtifactToNode(
   artifact: FacetsArtifact,
   canvasView: FacetsCanvasView,
   parentDirectionSetId: DirectionSetId | undefined,
+  reflowedPosition:
+    | {
+        x: number;
+        y: number;
+      }
+    | undefined,
   onToggleExpanded?: (artifactId: ArtifactId) => void,
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void,
   onUpdateDirection?: (
@@ -125,7 +143,7 @@ function mapArtifactToNode(
   return {
     id: artifact.id,
     type: "artifact",
-    position: nodeView.position,
+    position: reflowedPosition ?? nodeView.position,
     parentId: parentDirectionSetId,
     extent: parentDirectionSetId ? "parent" : undefined,
     data: getArtifactNodeData(
@@ -144,6 +162,73 @@ function mapArtifactToNode(
           minHeight: nodeView.size.height,
         }
       : undefined,
+  };
+}
+
+type DirectionSetLayout = {
+  childPositions: Map<ArtifactId, { x: number; y: number }>;
+  groupHeights: Map<DirectionSetId, number>;
+};
+
+function getDirectionSetLayout(
+  artifacts: FacetsArtifact[],
+  relationships: FacetsRelationship[],
+  canvasView: FacetsCanvasView,
+): DirectionSetLayout {
+  const directionById = new Map<ArtifactId, DirectionArtifact>();
+  const directionIdsBySetId = new Map<DirectionSetId, ArtifactId[]>();
+  const childPositions = new Map<ArtifactId, { x: number; y: number }>();
+  const groupHeights = new Map<DirectionSetId, number>();
+
+  artifacts.forEach((artifact) => {
+    if (artifact.type === "direction") {
+      directionById.set(artifact.id, artifact);
+    }
+  });
+
+  relationships.forEach((relationship) => {
+    if (
+      relationship.type === "contains_direction" &&
+      directionById.has(relationship.targetId)
+    ) {
+      const existingDirectionIds =
+        directionIdsBySetId.get(relationship.sourceId) ?? [];
+
+      directionIdsBySetId.set(relationship.sourceId, [
+        ...existingDirectionIds,
+        relationship.targetId,
+      ]);
+    }
+  });
+
+  directionIdsBySetId.forEach((directionIds, directionSetId) => {
+    let nextY = DIRECTION_SET_CHILD_START_Y;
+
+    directionIds.forEach((directionId) => {
+      const nodeView = canvasView.nodes[directionId];
+      const rowHeight = nodeView.expanded
+        ? DIRECTION_SET_EXPANDED_ROW_HEIGHT
+        : DIRECTION_SET_ROW_HEIGHT;
+
+      childPositions.set(directionId, {
+        x: nodeView.position.x,
+        y: nextY,
+      });
+      nextY += rowHeight;
+    });
+
+    groupHeights.set(
+      directionSetId,
+      Math.max(
+        DIRECTION_SET_BASE_HEIGHT + DIRECTION_SET_ROW_HEIGHT,
+        DIRECTION_SET_BASE_HEIGHT + nextY - DIRECTION_SET_CHILD_START_Y,
+      ),
+    );
+  });
+
+  return {
+    childPositions,
+    groupHeights,
   };
 }
 

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -13,6 +13,7 @@ import type {
   ArtifactNode,
   ArtifactNodeData,
   BriefArtifactPatch,
+  DirectionArtifactPatch,
   DirectionGroupNode,
   FacetsCanvasNode,
   RelationshipEdge,
@@ -32,6 +33,10 @@ export type MapProjectFileToReactFlowOptions = {
   canvasView?: FacetsCanvasView;
   onToggleExpanded?: (artifactId: ArtifactId) => void;
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void;
+  onUpdateDirection?: (
+    artifactId: ArtifactId,
+    patch: DirectionArtifactPatch,
+  ) => void;
   onGenerateDirections?: (directionSetId: DirectionSetId) => void;
 };
 
@@ -63,6 +68,7 @@ export function mapProjectFileToReactFlow(
           directionSetByDirectionId.get(artifact.id),
           options.onToggleExpanded,
           options.onUpdateBrief,
+          options.onUpdateDirection,
         ),
       ),
     ],
@@ -109,6 +115,10 @@ function mapArtifactToNode(
   parentDirectionSetId: DirectionSetId | undefined,
   onToggleExpanded?: (artifactId: ArtifactId) => void,
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void,
+  onUpdateDirection?: (
+    artifactId: ArtifactId,
+    patch: DirectionArtifactPatch,
+  ) => void,
 ): ArtifactNode {
   const nodeView = canvasView.nodes[artifact.id];
 
@@ -123,6 +133,7 @@ function mapArtifactToNode(
       Boolean(nodeView.expanded),
       onToggleExpanded,
       onUpdateBrief,
+      onUpdateDirection,
     ),
     draggable: false,
     selectable: false,
@@ -177,6 +188,10 @@ function getArtifactNodeData(
   expanded: boolean,
   onToggleExpanded?: (artifactId: ArtifactId) => void,
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void,
+  onUpdateDirection?: (
+    artifactId: ArtifactId,
+    patch: DirectionArtifactPatch,
+  ) => void,
 ): ArtifactNodeData {
   switch (artifact.type) {
     case "brief":
@@ -195,6 +210,7 @@ function getArtifactNodeData(
         summary: artifact.angle,
         expanded,
         onToggleExpanded,
+        onUpdateDirection,
       };
     case "prompt":
       return {

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -2,6 +2,7 @@ import type { Edge, Node } from "@xyflow/react";
 import type {
   ArtifactId,
   BriefArtifact,
+  DirectionArtifact,
   DirectionSet,
   DirectionSetId,
   FacetsArtifact,
@@ -12,6 +13,10 @@ export type BriefArtifactPatch = Partial<
   Pick<BriefArtifact, "title" | "brief" | "audience" | "constraints">
 >;
 
+export type DirectionArtifactPatch = Partial<
+  Pick<DirectionArtifact, "title" | "angle" | "notes" | "rationale">
+>;
+
 export type ArtifactNodeData = {
   artifact: FacetsArtifact;
   typeLabel: string;
@@ -19,6 +24,10 @@ export type ArtifactNodeData = {
   expanded: boolean;
   onToggleExpanded?: (artifactId: ArtifactId) => void;
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void;
+  onUpdateDirection?: (
+    artifactId: ArtifactId,
+    patch: DirectionArtifactPatch,
+  ) => void;
 };
 
 export type ArtifactNode = Node<ArtifactNodeData, "artifact">;


### PR DESCRIPTION
## Summary
- Scope #17 to editable Direction nodes only.
- Add expanded Direction editing for title, angle, notes, and rationale.
- Direction edits update the in-memory Facets artifact model through App state.
- Reflow contained Direction nodes when one expands so cards do not overlap.
- Prompt editing is deferred to #31.

## Issue #17 Acceptance Criteria
- [x] Expanded Direction nodes expose editable title, angle, notes, and rationale fields directly on the canvas.
- [x] Editing Direction nodes updates the in-memory Facets artifact model, not only React Flow node.data.
- [x] Clearing rationale stores an empty string.
- [x] Collapsed Direction nodes continue to render compact scan states with live title and live angle summary.
- [x] Expanding a Direction reflows later Directions in the set so cards do not overlap.
- [x] Brief editing remains unchanged.
- [x] Prompt nodes remain readonly if present later.
- [x] No selection, prompt creation, prompt copy/export, inspector, side panel, modal, fullscreen editor, persistence, model/API calls, or Figma MCP behavior is introduced.
- [x] `src/domain` remains free of React and `@xyflow/react` imports.

## Validation
- [x] `npm run build`
- [x] `git diff --check HEAD`
- [x] Confirmed `src/domain` has no React or `@xyflow/react` imports.
- [x] Browser validation on `http://127.0.0.1:1421/`: generated Directions, expanded a Direction, confirmed later Directions move below it without overlap, edited title/angle/notes/rationale, cleared rationale to blank, collapsed it, confirmed collapsed title/summary updated, and confirmed Brief editing still works.

Refs #17