### PR TITLE
Connect Brief to Direction Set

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import {
   Controls,
   Panel,
   ReactFlow,
+  type Connection,
   type EdgeTypes,
   type NodeTypes,
 } from "@xyflow/react";
@@ -19,6 +20,7 @@ import type {
   DirectionArtifact,
   DirectionSet,
   DirectionSetId,
+  FacetsProject,
   FacetsRelationship,
 } from "./domain";
 import { staticProjectFile } from "./fixtures/staticProject";
@@ -46,6 +48,49 @@ const nodeTypes = {
 const edgeTypes = {
   relationship: RelationshipEdge,
 } satisfies EdgeTypes;
+
+function isBriefArtifactId(
+  project: FacetsProject,
+  artifactId: string | null,
+): artifactId is ArtifactId {
+  return project.canvas.artifacts.some(
+    (artifact) => artifact.id === artifactId && artifact.type === "brief",
+  );
+}
+
+function isDirectionSetId(
+  project: FacetsProject,
+  directionSetId: string | null,
+): directionSetId is DirectionSetId {
+  return project.canvas.directionSets.some(
+    (directionSet) => directionSet.id === directionSetId,
+  );
+}
+
+function hasBriefToDirectionSetRelationship(
+  project: FacetsProject,
+  sourceBriefId: ArtifactId,
+  targetDirectionSetId: DirectionSetId,
+): boolean {
+  return project.canvas.relationships.some(
+    (relationship) =>
+      relationship.type === "brief_to_direction_set" &&
+      relationship.sourceId === sourceBriefId &&
+      relationship.targetId === targetDirectionSetId,
+  );
+}
+
+function canConnectBriefToDirectionSet(
+  project: FacetsProject,
+  sourceId: string | null,
+  targetId: string | null,
+): boolean {
+  return (
+    isBriefArtifactId(project, sourceId) &&
+    isDirectionSetId(project, targetId) &&
+    !hasBriefToDirectionSetRelationship(project, sourceId, targetId)
+  );
+}
 
 function App() {
   const [project, setProject] = useState(staticProjectFile.project);
@@ -251,6 +296,70 @@ function App() {
     });
   }, [canvasView, project]);
 
+  const handleConnectBriefToDirectionSet = useCallback(
+    (sourceBriefId: ArtifactId, targetDirectionSetId: DirectionSetId) => {
+      setProject((currentProject) => {
+        if (
+          !canConnectBriefToDirectionSet(
+            currentProject,
+            sourceBriefId,
+            targetDirectionSetId,
+          )
+        ) {
+          return currentProject;
+        }
+
+        const relationship: FacetsRelationship = {
+          id: `relationship-${sourceBriefId}-${targetDirectionSetId}`,
+          type: "brief_to_direction_set",
+          sourceId: sourceBriefId,
+          targetId: targetDirectionSetId,
+        };
+
+        return {
+          ...currentProject,
+          canvas: {
+            ...currentProject.canvas,
+            relationships: [
+              ...currentProject.canvas.relationships,
+              relationship,
+            ],
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const handleConnect = useCallback(
+    (connection: Connection) => {
+      if (
+        !canConnectBriefToDirectionSet(
+          project,
+          connection.source,
+          connection.target,
+        ) ||
+        !connection.source ||
+        !connection.target
+      ) {
+        return;
+      }
+
+      handleConnectBriefToDirectionSet(connection.source, connection.target);
+    },
+    [handleConnectBriefToDirectionSet, project],
+  );
+
+  const isValidConnection = useCallback(
+    (connection: { source?: string | null; target?: string | null }) =>
+      canConnectBriefToDirectionSet(
+        project,
+        connection.source ?? null,
+        connection.target ?? null,
+      ),
+    [project],
+  );
+
   const staticGraph = useMemo(
     () =>
       mapProjectFileToReactFlow(staticProjectFile, {
@@ -278,9 +387,11 @@ function App() {
         edges={staticGraph.edges}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
+        onConnect={handleConnect}
+        isValidConnection={isValidConnection}
         fitView
         nodesDraggable={false}
-        nodesConnectable={false}
+        nodesConnectable
         elementsSelectable
         edgesReconnectable={false}
         deleteKeyCode={null}

--- a/src/canvas/ArtifactNode.tsx
+++ b/src/canvas/ArtifactNode.tsx
@@ -35,7 +35,11 @@ function ArtifactNode({ data }: NodeProps<ArtifactNodeType>) {
         </button>
       </header>
       <ArtifactNodeBody data={data} />
-      <Handle type="source" position={Position.Right} isConnectable={false} />
+      <Handle
+        type="source"
+        position={Position.Right}
+        isConnectable={data.canStartConnection}
+      />
     </article>
   );
 }

--- a/src/canvas/DirectionGroupNode.tsx
+++ b/src/canvas/DirectionGroupNode.tsx
@@ -20,7 +20,11 @@ function DirectionGroupNode({ data }: NodeProps<DirectionGroupNodeType>) {
 
   return (
     <section className="direction-group-node">
-      <Handle type="target" position={Position.Left} isConnectable={false} />
+      <Handle
+        type="target"
+        position={Position.Left}
+        isConnectable={data.canAcceptConnection}
+      />
       <header className="direction-group-node__header">
         <div className="direction-group-node__title">
           <span>{data.directionSet.title}</span>

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -67,6 +67,7 @@ export function mapProjectFileToReactFlow(
           getDirectionCount(directionSet.id, project.canvas.relationships),
           directionSetLayout.groupHeights.get(directionSet.id),
           isDirectionSetConnected(directionSet.id, project.canvas.relationships),
+          true,
           options.onGenerateDirections,
         ),
       ),
@@ -94,6 +95,7 @@ function mapDirectionSetToNode(
   directionCount: number,
   groupHeight: number | undefined,
   canGenerate: boolean,
+  canAcceptConnection: boolean,
   onGenerateDirections?: (directionSetId: DirectionSetId) => void,
 ): DirectionGroupNode {
   const nodeView = canvasView.nodes[directionSet.id];
@@ -106,6 +108,7 @@ function mapDirectionSetToNode(
       directionSet,
       count: directionCount,
       canGenerate,
+      canAcceptConnection,
       onGenerateDirections,
     },
     draggable: false,
@@ -285,6 +288,7 @@ function getArtifactNodeData(
         typeLabel: "Brief",
         summary: artifact.brief,
         expanded,
+        canStartConnection: true,
         onToggleExpanded,
         onUpdateBrief,
       };
@@ -294,6 +298,7 @@ function getArtifactNodeData(
         typeLabel: "Direction",
         summary: artifact.angle,
         expanded,
+        canStartConnection: false,
         onToggleExpanded,
         onUpdateDirection,
       };
@@ -303,6 +308,7 @@ function getArtifactNodeData(
         typeLabel: "Prompt",
         summary: artifact.summary,
         expanded,
+        canStartConnection: false,
         onToggleExpanded,
       };
   }

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -22,6 +22,7 @@ export type ArtifactNodeData = {
   typeLabel: string;
   summary: string;
   expanded: boolean;
+  canStartConnection: boolean;
   onToggleExpanded?: (artifactId: ArtifactId) => void;
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void;
   onUpdateDirection?: (
@@ -36,6 +37,7 @@ export type DirectionGroupNodeData = {
   directionSet: DirectionSet;
   count: number;
   canGenerate: boolean;
+  canAcceptConnection: boolean;
   onGenerateDirections?: (directionSetId: DirectionSetId) => void;
 };
 


### PR DESCRIPTION
## Summary
- Add a limited React Flow drag-to-connect gesture from Brief source handles to Direction Set target handles.
- Validate connections against the Facets domain model in `App.tsx`.
- Append `brief_to_direction_set` relationships to `project.canvas.relationships`; React Flow edge state is never persisted directly.
- Keep visible edges derived from Facets relationships in the mapper.

## Issue #28 Acceptance Criteria
- [x] An unconnected Direction Set can be connected to the Brief from the canvas UI.
- [x] Connecting creates a `brief_to_direction_set` relationship in `project.canvas.relationships`.
- [x] The connected Direction Set shows `Generate directions` when empty.
- [x] Clicking `Generate directions` in the newly connected set adds three Direction artifacts to that set only.
- [x] The new Brief-to-set edge is visible.
- [x] `contains_direction` relationships still do not render as visible edges.
- [x] Duplicate Brief-to-set connections are guarded in both validation and relationship append paths.
- [x] No persistence/save-load implementation, API/model calls, prompt copy/export, side panel, modal, inspector, fullscreen editor, or Figma MCP behavior is introduced.
- [x] `src/domain` remains free of React and `@xyflow/react` imports.

## Validation
- [x] `npm run build`
- [x] `git diff --check`
- [x] Confirmed `src/domain` has no React or `@xyflow/react` imports.
- [x] Browser validation on `http://127.0.0.1:1421/`: created a new Direction Set, fit the view, dragged from the Brief handle to the new set handle, confirmed one new visible Brief-to-set edge, confirmed generation became enabled, confirmed duplicate drag did not create a duplicate edge, and generated three Directions in each connected set while keeping counts separate.

Refs #28