### PR TITLE
Disconnect Brief from Direction Set

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 import {
   Background,
   Controls,
@@ -13,7 +19,11 @@ import ArtifactNode from "./canvas/ArtifactNode";
 import DirectionGroupNode from "./canvas/DirectionGroupNode";
 import { mapProjectFileToReactFlow } from "./canvas/mapFacetsToReactFlow";
 import RelationshipEdge from "./canvas/RelationshipEdge";
-import type { BriefArtifactPatch, DirectionArtifactPatch } from "./canvas/types";
+import type {
+  BriefArtifactPatch,
+  DirectionArtifactPatch,
+  RelationshipEdge as RelationshipEdgeType,
+} from "./canvas/types";
 import type {
   ArtifactId,
   BriefArtifact,
@@ -95,6 +105,9 @@ function canConnectBriefToDirectionSet(
 function App() {
   const [project, setProject] = useState(staticProjectFile.project);
   const [canvasView, setCanvasView] = useState(staticProjectFile.canvasView);
+  const [selectedRelationshipId, setSelectedRelationshipId] = useState<
+    string | null
+  >(null);
 
   const handleToggleExpanded = useCallback((artifactId: ArtifactId) => {
     setCanvasView((currentCanvasView) => {
@@ -360,6 +373,83 @@ function App() {
     [project],
   );
 
+  const handleEdgesDelete = useCallback(
+    (deletedEdges: RelationshipEdgeType[]) => {
+      const deletedEdgeIds = new Set(deletedEdges.map((edge) => edge.id));
+
+      setProject((currentProject) => ({
+        ...currentProject,
+        canvas: {
+          ...currentProject.canvas,
+          relationships: currentProject.canvas.relationships.filter(
+            (relationship) =>
+              relationship.type !== "brief_to_direction_set" ||
+              !deletedEdgeIds.has(relationship.id),
+          ),
+        },
+      }));
+      setSelectedRelationshipId(null);
+    },
+    [],
+  );
+
+  const handleDisconnectBriefFromDirectionSet = useCallback(
+    (relationshipId: string) => {
+      setProject((currentProject) => ({
+        ...currentProject,
+        canvas: {
+          ...currentProject.canvas,
+          relationships: currentProject.canvas.relationships.filter(
+            (relationship) =>
+              relationship.id !== relationshipId ||
+              relationship.type !== "brief_to_direction_set",
+          ),
+        },
+      }));
+      setSelectedRelationshipId(null);
+    },
+    [],
+  );
+
+  const handleEdgeClick = useCallback(
+    (
+      event: ReactMouseEvent<Element>,
+      edge: RelationshipEdgeType,
+    ) => {
+      event.stopPropagation();
+      setSelectedRelationshipId(
+        edge.data?.relationship.type === "brief_to_direction_set"
+          ? edge.data.relationship.id
+          : null,
+      );
+    },
+    [],
+  );
+
+  const handlePaneClick = useCallback(() => {
+    setSelectedRelationshipId(null);
+  }, []);
+
+  useEffect(() => {
+    function handleWindowKeyDown(event: KeyboardEvent) {
+      if (
+        !selectedRelationshipId ||
+        (event.key !== "Delete" && event.key !== "Backspace")
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      handleDisconnectBriefFromDirectionSet(selectedRelationshipId);
+    }
+
+    window.addEventListener("keydown", handleWindowKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleWindowKeyDown);
+    };
+  }, [handleDisconnectBriefFromDirectionSet, selectedRelationshipId]);
+
   const staticGraph = useMemo(
     () =>
       mapProjectFileToReactFlow(staticProjectFile, {
@@ -369,6 +459,7 @@ function App() {
         onUpdateBrief: handleUpdateBrief,
         onUpdateDirection: handleUpdateDirection,
         onGenerateDirections: handleGenerateDirections,
+        selectedRelationshipId,
       }),
     [
       canvasView,
@@ -377,6 +468,7 @@ function App() {
       handleUpdateBrief,
       handleUpdateDirection,
       project,
+      selectedRelationshipId,
     ],
   );
 
@@ -389,12 +481,15 @@ function App() {
         edgeTypes={edgeTypes}
         onConnect={handleConnect}
         isValidConnection={isValidConnection}
+        onEdgesDelete={handleEdgesDelete}
+        onEdgeClick={handleEdgeClick}
+        onPaneClick={handlePaneClick}
         fitView
         nodesDraggable={false}
         nodesConnectable
         elementsSelectable
         edgesReconnectable={false}
-        deleteKeyCode={null}
+        deleteKeyCode={["Backspace", "Delete"]}
       >
         <Panel position="top-left" className="canvas-toolbar">
           <button

--- a/src/canvas/RelationshipEdge.tsx
+++ b/src/canvas/RelationshipEdge.tsx
@@ -1,5 +1,6 @@
 import {
   BaseEdge,
+  EdgeLabelRenderer,
   getSmoothStepPath,
   type EdgeProps,
 } from "@xyflow/react";
@@ -14,8 +15,9 @@ function RelationshipEdge({
   sourcePosition,
   targetPosition,
   label,
+  selected,
 }: EdgeProps<RelationshipEdgeType>) {
-  const [edgePath] = getSmoothStepPath({
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
     sourceX,
     sourceY,
     sourcePosition,
@@ -24,7 +26,35 @@ function RelationshipEdge({
     targetPosition,
   });
 
-  return <BaseEdge id={id} path={edgePath} label={label} />;
+  return (
+    <>
+      {selected ? (
+        <path className="relationship-edge__selection-halo" d={edgePath} />
+      ) : null}
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        label={label}
+        className={
+          selected
+            ? "relationship-edge relationship-edge--selected"
+            : "relationship-edge"
+        }
+      />
+      {selected ? (
+        <EdgeLabelRenderer>
+          <div
+            className="relationship-edge__selection-label"
+            style={{
+              transform: `translate(8px, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+          >
+            Selected · Delete
+          </div>
+        </EdgeLabelRenderer>
+      ) : null}
+    </>
+  );
 }
 
 export default RelationshipEdge;

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -41,6 +41,7 @@ export type MapProjectFileToReactFlowOptions = {
     patch: DirectionArtifactPatch,
   ) => void;
   onGenerateDirections?: (directionSetId: DirectionSetId) => void;
+  selectedRelationshipId?: string | null;
 };
 
 export function mapProjectFileToReactFlow(
@@ -85,7 +86,9 @@ export function mapProjectFileToReactFlow(
     ],
     edges: project.canvas.relationships
       .filter((relationship) => relationship.type !== "contains_direction")
-      .map(mapRelationshipToEdge),
+      .map((relationship) =>
+        mapRelationshipToEdge(relationship, options.selectedRelationshipId),
+      ),
   };
 }
 
@@ -316,6 +319,7 @@ function getArtifactNodeData(
 
 function mapRelationshipToEdge(
   relationship: FacetsRelationship,
+  selectedRelationshipId: string | null | undefined,
 ): RelationshipEdge {
   return {
     id: relationship.id,
@@ -324,7 +328,8 @@ function mapRelationshipToEdge(
     target: relationship.targetId,
     label: getRelationshipLabel(relationship),
     data: { relationship },
-    selectable: false,
+    selectable: relationship.type === "brief_to_direction_set",
+    selected: relationship.id === selectedRelationshipId,
     reconnectable: false,
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -49,6 +49,36 @@ body {
   stroke-width: 1.6;
 }
 
+.relationship-edge--selected .react-flow__edge-path {
+  stroke: #1f7c60;
+  stroke-width: 3;
+}
+
+.relationship-edge__selection-halo {
+  fill: none;
+  stroke: rgba(31, 124, 96, 0.18);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 12;
+  pointer-events: none;
+}
+
+.relationship-edge__selection-label {
+  position: absolute;
+  z-index: 20;
+  padding: 5px 8px;
+  color: #fffdf7;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0;
+  white-space: nowrap;
+  background: #1f7c60;
+  border: 1px solid rgba(31, 35, 32, 0.12);
+  border-radius: 999px;
+  box-shadow: 0 10px 28px rgba(54, 48, 36, 0.16);
+  pointer-events: none;
+}
+
 .react-flow__edge-textbg {
   fill: #f6f2e8;
 }


### PR DESCRIPTION
## Summary
- Adds selected relationship state for Brief-to-Direction Set edges.
- Removes selected brief_to_direction_set relationships from Facets project state with Delete or Backspace.
- Keeps React Flow edges derived from Facets relationships instead of persisting React Flow edge state.

## Issue
Links #34

## Acceptance Criteria
- [x] Brief-to-Direction Set edges can be selected.
- [x] Pressing Delete removes the selected Brief-to-Direction Set relationship.
- [x] Pressing Backspace removes the selected Brief-to-Direction Set relationship.
- [x] Direction Set generation becomes disabled after the relationship is removed.
- [x] Other relationship types are not made deletable.
- [x] React Flow remains the interaction layer; Facets project data remains the source of truth.

## Validation
- [x] npm run build
- [x] git diff --check HEAD
- [x] Confirmed src/domain has no React or @xyflow/react imports
- [x] Browser verified: create Direction Set, connect Brief, generate Directions, select edge, Delete removes edge and disables generation while Directions remain
- [x] Browser verified: Backspace removes the initial Brief-to-Direction Set edge and disables generation
- [x] Browser console had no errors