### PR TITLE
Select multiple Directions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,6 +105,9 @@ function canConnectBriefToDirectionSet(
 function App() {
   const [project, setProject] = useState(staticProjectFile.project);
   const [canvasView, setCanvasView] = useState(staticProjectFile.canvasView);
+  const [selectedDirectionIds, setSelectedDirectionIds] = useState<
+    Set<ArtifactId>
+  >(() => new Set());
   const [selectedRelationshipId, setSelectedRelationshipId] = useState<
     string | null
   >(null);
@@ -159,6 +162,35 @@ function App() {
     },
     [],
   );
+
+  const handleToggleDirectionSelected = useCallback(
+    (artifactId: ArtifactId) => {
+      const isDirection = project.canvas.artifacts.some(
+        (artifact) => artifact.id === artifactId && artifact.type === "direction",
+      );
+
+      if (!isDirection) {
+        return;
+      }
+
+      setSelectedDirectionIds((currentSelectedDirectionIds) => {
+        const nextSelectedDirectionIds = new Set(currentSelectedDirectionIds);
+
+        if (nextSelectedDirectionIds.has(artifactId)) {
+          nextSelectedDirectionIds.delete(artifactId);
+        } else {
+          nextSelectedDirectionIds.add(artifactId);
+        }
+
+        return nextSelectedDirectionIds;
+      });
+    },
+    [project],
+  );
+
+  const handleClearDirectionSelection = useCallback(() => {
+    setSelectedDirectionIds(new Set());
+  }, []);
 
   const handleGenerateDirections = useCallback(
     (directionSetId: DirectionSetId) => {
@@ -458,6 +490,8 @@ function App() {
         onToggleExpanded: handleToggleExpanded,
         onUpdateBrief: handleUpdateBrief,
         onUpdateDirection: handleUpdateDirection,
+        selectedDirectionIds,
+        onToggleDirectionSelected: handleToggleDirectionSelected,
         onGenerateDirections: handleGenerateDirections,
         selectedRelationshipId,
       }),
@@ -467,10 +501,18 @@ function App() {
       handleToggleExpanded,
       handleUpdateBrief,
       handleUpdateDirection,
+      handleToggleDirectionSelected,
       project,
+      selectedDirectionIds,
       selectedRelationshipId,
     ],
   );
+
+  const selectedDirectionCount = selectedDirectionIds.size;
+  const selectedDirectionCountLabel =
+    selectedDirectionCount === 1
+      ? "1 direction selected"
+      : `${selectedDirectionCount} directions selected`;
 
   return (
     <main className="app-shell" aria-label="Facets canvas">
@@ -498,6 +540,17 @@ function App() {
             onClick={handleCreateDirectionSet}
           >
             New direction set
+          </button>
+          <span className="canvas-toolbar__status">
+            {selectedDirectionCountLabel}
+          </span>
+          <button
+            className="canvas-toolbar__button canvas-toolbar__button--secondary nodrag nopan"
+            type="button"
+            disabled={selectedDirectionCount === 0}
+            onClick={handleClearDirectionSelection}
+          >
+            Clear selection
           </button>
         </Panel>
         <Background />

--- a/src/canvas/ArtifactNode.tsx
+++ b/src/canvas/ArtifactNode.tsx
@@ -9,10 +9,17 @@ import type {
 
 function ArtifactNode({ data }: NodeProps<ArtifactNodeType>) {
   const toggleLabel = data.expanded ? "Collapse" : "Expand";
+  const canSelectDirection = data.artifact.type === "direction";
+  const selectionLabel = data.selected ? "Selected" : "Select";
 
   function handleToggleClick(event: MouseEvent<HTMLButtonElement>) {
     event.stopPropagation();
     data.onToggleExpanded?.(data.artifact.id);
+  }
+
+  function handleSelectClick(event: MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+    data.onToggleDirectionSelected?.(data.artifact.id);
   }
 
   return (
@@ -21,18 +28,37 @@ function ArtifactNode({ data }: NodeProps<ArtifactNodeType>) {
         "artifact-node",
         `artifact-node--${data.artifact.type}`,
         data.expanded ? "artifact-node--expanded" : "artifact-node--collapsed",
+        data.selected ? "artifact-node--selected" : "",
       ].join(" ")}
     >
       <Handle type="target" position={Position.Left} isConnectable={false} />
       <header className="artifact-node__header">
         <div className="artifact-node__eyebrow">{data.typeLabel}</div>
-        <button
-          className="artifact-node__action nodrag nopan"
-          type="button"
-          onClick={handleToggleClick}
-        >
-          {toggleLabel}
-        </button>
+        <div className="artifact-node__actions">
+          {canSelectDirection ? (
+            <button
+              className={[
+                "artifact-node__action",
+                "artifact-node__action--select",
+                data.selected ? "artifact-node__action--selected" : "",
+                "nodrag",
+                "nopan",
+              ].join(" ")}
+              type="button"
+              aria-pressed={data.selected}
+              onClick={handleSelectClick}
+            >
+              {selectionLabel}
+            </button>
+          ) : null}
+          <button
+            className="artifact-node__action nodrag nopan"
+            type="button"
+            onClick={handleToggleClick}
+          >
+            {toggleLabel}
+          </button>
+        </div>
       </header>
       <ArtifactNodeBody data={data} />
       <Handle

--- a/src/canvas/mapFacetsToReactFlow.ts
+++ b/src/canvas/mapFacetsToReactFlow.ts
@@ -40,6 +40,8 @@ export type MapProjectFileToReactFlowOptions = {
     artifactId: ArtifactId,
     patch: DirectionArtifactPatch,
   ) => void;
+  selectedDirectionIds?: ReadonlySet<ArtifactId>;
+  onToggleDirectionSelected?: (artifactId: ArtifactId) => void;
   onGenerateDirections?: (directionSetId: DirectionSetId) => void;
   selectedRelationshipId?: string | null;
 };
@@ -79,6 +81,8 @@ export function mapProjectFileToReactFlow(
           directionSetByDirectionId.get(artifact.id),
           directionSetLayout.childPositions.get(artifact.id),
           options.onToggleExpanded,
+          options.selectedDirectionIds,
+          options.onToggleDirectionSelected,
           options.onUpdateBrief,
           options.onUpdateDirection,
         ),
@@ -138,6 +142,8 @@ function mapArtifactToNode(
       }
     | undefined,
   onToggleExpanded?: (artifactId: ArtifactId) => void,
+  selectedDirectionIds?: ReadonlySet<ArtifactId>,
+  onToggleDirectionSelected?: (artifactId: ArtifactId) => void,
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void,
   onUpdateDirection?: (
     artifactId: ArtifactId,
@@ -155,7 +161,9 @@ function mapArtifactToNode(
     data: getArtifactNodeData(
       artifact,
       Boolean(nodeView.expanded),
+      selectedDirectionIds?.has(artifact.id) ?? false,
       onToggleExpanded,
+      onToggleDirectionSelected,
       onUpdateBrief,
       onUpdateDirection,
     ),
@@ -277,7 +285,9 @@ function isDirectionSetConnected(
 function getArtifactNodeData(
   artifact: FacetsArtifact,
   expanded: boolean,
+  selected: boolean,
   onToggleExpanded?: (artifactId: ArtifactId) => void,
+  onToggleDirectionSelected?: (artifactId: ArtifactId) => void,
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void,
   onUpdateDirection?: (
     artifactId: ArtifactId,
@@ -291,6 +301,7 @@ function getArtifactNodeData(
         typeLabel: "Brief",
         summary: artifact.brief,
         expanded,
+        selected: false,
         canStartConnection: true,
         onToggleExpanded,
         onUpdateBrief,
@@ -301,8 +312,10 @@ function getArtifactNodeData(
         typeLabel: "Direction",
         summary: artifact.angle,
         expanded,
+        selected,
         canStartConnection: false,
         onToggleExpanded,
+        onToggleDirectionSelected,
         onUpdateDirection,
       };
     case "prompt":
@@ -311,6 +324,7 @@ function getArtifactNodeData(
         typeLabel: "Prompt",
         summary: artifact.summary,
         expanded,
+        selected: false,
         canStartConnection: false,
         onToggleExpanded,
       };

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -22,8 +22,10 @@ export type ArtifactNodeData = {
   typeLabel: string;
   summary: string;
   expanded: boolean;
+  selected: boolean;
   canStartConnection: boolean;
   onToggleExpanded?: (artifactId: ArtifactId) => void;
+  onToggleDirectionSelected?: (artifactId: ArtifactId) => void;
   onUpdateBrief?: (artifactId: ArtifactId, patch: BriefArtifactPatch) => void;
   onUpdateDirection?: (
     artifactId: ArtifactId,

--- a/src/styles.css
+++ b/src/styles.css
@@ -132,9 +132,34 @@ body {
   background: #176b52;
 }
 
+.canvas-toolbar__button:disabled,
+.canvas-toolbar__button:disabled:hover {
+  color: #6d6a61;
+  background: #f2eee3;
+  border-color: rgba(31, 35, 32, 0.12);
+  cursor: default;
+}
+
+.canvas-toolbar__button--secondary {
+  color: #1f211d;
+  background: #fffdf7;
+}
+
+.canvas-toolbar__button--secondary:hover {
+  background: #eee8d9;
+}
+
 .canvas-toolbar__button:focus-visible {
   outline: 3px solid rgba(31, 124, 96, 0.24);
   outline-offset: 2px;
+}
+
+.canvas-toolbar__status {
+  color: #5f594f;
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0;
+  white-space: nowrap;
 }
 
 .direction-group-node {
@@ -237,6 +262,13 @@ body {
   border-color: rgba(88, 99, 131, 0.3);
 }
 
+.artifact-node--direction.artifact-node--selected {
+  border-color: rgba(31, 124, 96, 0.64);
+  box-shadow:
+    0 0 0 4px rgba(31, 124, 96, 0.12),
+    0 18px 48px rgba(54, 48, 36, 0.12);
+}
+
 .artifact-node--prompt {
   border-color: rgba(146, 94, 55, 0.3);
 }
@@ -248,6 +280,12 @@ body {
   gap: 12px;
   min-height: 28px;
   margin-bottom: 14px;
+}
+
+.artifact-node__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .artifact-node__eyebrow {
@@ -372,6 +410,13 @@ body {
 
 .artifact-node__action:hover {
   background: #eee8d9;
+}
+
+.artifact-node__action--selected,
+.artifact-node__action--selected:hover {
+  color: #fffdf7;
+  background: #1f7c60;
+  border-color: rgba(31, 124, 96, 0.5);
 }
 
 .artifact-node__action:focus-visible {


### PR DESCRIPTION
## Summary
- Adds Facets-owned in-memory selection for Direction artifacts.
- Adds Direction node header `Select` / `Selected` toggles and selected node styling.
- Adds toolbar selected count and `Clear selection` action.

## Issue
Links #29

## Acceptance Criteria
- [x] A user can select and deselect individual Direction nodes.
- [x] Multiple Direction nodes can be selected at the same time.
- [x] Selected state is stored in Facets-owned in-memory state, not React Flow node selection.
- [x] Selected state is visible on selected Direction nodes.
- [x] Selection works across Direction Sets.
- [x] The canvas toolbar shows selected Direction count.
- [x] `Clear selection` clears all selected Directions and is disabled when none are selected.
- [x] Editing Direction content does not clear selection.
- [x] No prompt creation, prompt copy/export, persistence/save-load implementation, API/model calls, side panel, modal, inspector, fullscreen editor, or Figma MCP behavior is introduced.
- [x] `src/domain` remains free of React and `@xyflow/react` imports.

## Validation
- [x] `npm run build`
- [x] `git diff --check HEAD`
- [x] Confirmed `src/domain` has no React or `@xyflow/react` imports
- [x] Browser verified generating Directions, selecting/deselecting multiple Directions, clearing selection, editing while selected, and selecting across two Direction Sets
- [x] Browser console had no errors
